### PR TITLE
feat(NameRegistry): allow withdrawal of funds to a vault

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,3 @@
 IDRegistryGasUsageTest:testGasRegister() (gas: 799599)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedSender() (gas: 841252)
-NameRegistryGasUsageTest:testGasUsage() (gas: 2334436)
+NameRegistryGasUsageTest:testGasUsage() (gas: 2334972)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,3 @@
 IDRegistryGasUsageTest:testGasRegister() (gas: 799599)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedSender() (gas: 841252)
-NameRegistryGasUsageTest:testGasUsage() (gas: 2330641)
+NameRegistryGasUsageTest:testGasUsage() (gas: 2330705)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,3 @@
 IDRegistryGasUsageTest:testGasRegister() (gas: 799599)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedSender() (gas: 841252)
-NameRegistryGasUsageTest:testGasUsage() (gas: 2334972)
+NameRegistryGasUsageTest:testGasUsage() (gas: 2330641)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -122,16 +122,16 @@ The fname state can automatically transition when certain periods of time pass:
 
 ### Permissions
 
-The Name Registry, unlike the ID Registry, implements an Access Control system that defines roles which can be granted to different addresses. The system has three high permissioned roles which must be kept secure to perform infrequent, sensitive operations:
+The Name Registry, unlike the ID Registry, implements an Access Control system that defines roles which can be granted to different addresses. The system has two high permissioned roles which must be kept secure to perform infrequent, sensitive operations:
 
-- **Default Administrator** - Can grant and revoke all other roles.
-- **Owner** - Used to upgrade the contract, change the trusted sender and disable trusted sending.
-- **Treasurer** - Used to withdraw funds and set the fee rate.
+- **Default Admin** - Can grant and revoke all other roles, including Admin.
+- **Admin** - Used to upgrade the contract, change the vault, change the trusted sender and disable trusted sending.
 
-The system also has two lower permissioned roles that can be granted to people performing more frequent operations:
+The system also has three lower permissioned roles that can be granted to people performing more frequent operations:
 
 - **Operator** - Used by on-call teams to pause and resume the contract.
 - **Moderator** - Used by moderators to reclaim names from users and change the location to which they are reclaimed.
+- **Treasurer** - Used to withdraw funds to the vault and set the fee rate.
 
 ## 3. Recovery System
 

--- a/script/NameRegistry.s.sol
+++ b/script/NameRegistry.s.sol
@@ -15,8 +15,9 @@ contract NameRegistryScript is Script {
     NameRegistry proxiedNameRegistry;
     ERC1967Proxy proxy;
 
-    // TODO: Fix the vault address
-    address vault = address(0x123);
+    // TODO: Fix the vault and pool address
+    address constant VAULT = address(0x123);
+    address constant POOL = address(0x456);
 
     function run() public {
         vm.broadcast();
@@ -27,6 +28,6 @@ contract NameRegistryScript is Script {
         proxiedNameRegistry = NameRegistry(address(proxy));
 
         vm.broadcast();
-        proxiedNameRegistry.initialize("Farcaster NameRegistry", "FCN", vault);
+        proxiedNameRegistry.initialize("Farcaster NameRegistry", "FCN", VAULT, POOL);
     }
 }

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -70,6 +70,8 @@ contract NameRegistry is
 
     event CancelRecovery(uint256 indexed id);
 
+    event ChangeVault(address indexed vault);
+
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -710,6 +712,15 @@ contract NameRegistry is
     function disableTrustedRegister() external {
         if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
         trustedRegisterEnabled = 0;
+    }
+
+    /**
+     * @notice Changes the address to which funds can be withdrawn
+     */
+    function changeVault(address _vault) external {
+        if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
+        vault = _vault;
+        emit ChangeVault(_vault);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -127,7 +127,7 @@ contract NameRegistry is
     uint256 public constant ESCROW_PERIOD = 3 days;
 
     // TODO: Does this work correctly in an upgraded contract?
-    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
 
@@ -177,7 +177,6 @@ contract NameRegistry is
         __UUPSUpgradeable_init();
 
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        _setupRole(OWNER_ROLE, _msgSender());
 
         vault = _vault;
 
@@ -702,7 +701,7 @@ contract NameRegistry is
      * @notice Changes the address from which registerTrusted calls can be made
      */
     function setTrustedSender(address _trustedSender) external {
-        if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
+        if (!hasRole(ADMIN_ROLE, _msgSender())) revert NotOwner();
         trustedSender = _trustedSender;
     }
 
@@ -710,7 +709,7 @@ contract NameRegistry is
      * @notice Disables registerTrusted and enables register calls from any address.
      */
     function disableTrustedRegister() external {
-        if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
+        if (!hasRole(ADMIN_ROLE, _msgSender())) revert NotOwner();
         trustedRegisterEnabled = 0;
     }
 
@@ -718,7 +717,7 @@ contract NameRegistry is
      * @notice Changes the address to which funds can be withdrawn
      */
     function changeVault(address _vault) external {
-        if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
+        if (!hasRole(ADMIN_ROLE, _msgSender())) revert NotOwner();
         vault = _vault;
         emit ChangeVault(_vault);
     }
@@ -833,7 +832,7 @@ contract NameRegistry is
 
     // solhint-disable-next-line no-empty-blocks
     function _authorizeUpgrade(address) internal view override {
-        if (!hasRole(OWNER_ROLE, _msgSender())) revert NotOwner();
+        if (!hasRole(ADMIN_ROLE, _msgSender())) revert NotOwner();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/MetaTx.t.sol
+++ b/test/MetaTx.t.sol
@@ -5,7 +5,6 @@ import "forge-std/Test.sol";
 import {IDRegistryTestable} from "./Utils.sol";
 import {NameRegistry} from "../src/NameRegistry.sol";
 import {MinimalForwarder} from "openzeppelin/contracts/metatx/MinimalForwarder.sol";
-import {EIP712} from "openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import {ERC1967Proxy} from "openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /* solhint-disable state-visibility */
@@ -24,6 +23,10 @@ contract MetaTxTest is Test {
                                 CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
+    address defaultAdmin = address(this);
+    address constant POOL = address(0xFe4ECfAAF678A24a6661DB61B573FEf3591bcfD6);
+    address constant VAULT = address(0xec185Fa332C026e2d4Fc101B891B51EFc78D8836);
+
     bytes32 private constant _TYPEHASH_FW_REQ =
         keccak256("ForwardRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data)");
 
@@ -35,6 +38,8 @@ contract MetaTxTest is Test {
 
     // A timestamp during which registrations are allowed - Dec 1, 2022 00:00:00 GMT
     uint256 constant DEC1_2022_TS = 1669881600;
+
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
     /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
@@ -51,7 +56,8 @@ contract MetaTxTest is Test {
         nameRegistryImpl = new NameRegistry(address(forwarder));
         nameRegistryProxy = new ERC1967Proxy(address(nameRegistryImpl), "");
         nameRegistry = NameRegistry(address(nameRegistryProxy));
-        nameRegistry.initialize("Farcaster NameRegistry", "FCN", address(this));
+        nameRegistry.initialize("Farcaster NameRegistry", "FCN", VAULT, POOL);
+        nameRegistry.grantRole(ADMIN_ROLE, defaultAdmin);
         nameRegistry.disableTrustedRegister();
     }
 

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -24,6 +24,7 @@ contract NameRegistryTest is Test {
     event ChangeRecoveryAddress(uint256 indexed tokenId, address indexed recovery);
     event RequestRecovery(address indexed from, address indexed to, uint256 indexed id);
     event CancelRecovery(uint256 indexed id);
+    event ChangeVault(address indexed vault);
 
     /*//////////////////////////////////////////////////////////////
                                 CONSTANTS
@@ -2060,6 +2061,28 @@ contract NameRegistryTest is Test {
         vm.expectRevert(NameRegistry.NotOwner.selector);
         nameRegistry.disableTrustedRegister();
         assertEq(nameRegistry.trustedRegisterEnabled(), 1);
+    }
+
+    function testChangeVault(address alice, address bob) public {
+        vm.assume(alice != nameRegistry.trustedSender());
+        assertEq(nameRegistry.vault(), vault);
+        _grant(OWNER_ROLE, alice);
+
+        vm.prank(alice);
+        vm.expectEmit(true, false, false, true);
+        emit ChangeVault(bob);
+        nameRegistry.changeVault(bob);
+        assertEq(nameRegistry.vault(), bob);
+    }
+
+    function testCannotChangeVaultUnlessOwner(address alice, address bob) public {
+        vm.assume(alice != nameRegistry.trustedSender());
+        assertEq(nameRegistry.vault(), vault);
+
+        vm.prank(alice);
+        vm.expectRevert(NameRegistry.NotOwner.selector);
+        nameRegistry.changeVault(bob);
+        assertEq(nameRegistry.vault(), vault);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2213,6 +2213,20 @@ contract NameRegistryTest is Test {
         assertEq(address(nameRegistry).balance, 1 ether);
     }
 
+    function testCannotWithdrawToNonPayableAddress(address alice) public {
+        _assumeClean(alice);
+        _grant(TREASURER_ROLE, alice);
+        vm.deal(address(nameRegistry), 1 ether);
+
+        vm.prank(ADMIN);
+        nameRegistry.changeVault(address(this));
+
+        vm.prank(alice);
+        vm.expectRevert(NameRegistry.WithdrawFailed.selector);
+        nameRegistry.withdraw(1 ether);
+        assertEq(address(nameRegistry).balance, 1 ether);
+    }
+
     /*//////////////////////////////////////////////////////////////
                              OPERATOR TESTS
     //////////////////////////////////////////////////////////////*/

--- a/test/NameRegistryGasUsage.t.sol
+++ b/test/NameRegistryGasUsage.t.sol
@@ -12,7 +12,8 @@ contract NameRegistryGasUsageTest is Test {
     NameRegistry nameRegistry;
     ERC1967Proxy nameRegistryProxy;
 
-    address vault = address(this);
+    address constant POOL = address(0xFe4ECfAAF678A24a6661DB61B573FEf3591bcfD6);
+    address constant VAULT = address(0xec185Fa332C026e2d4Fc101B891B51EFc78D8836);
 
     /*//////////////////////////////////////////////////////////////
                                 CONSTANTS
@@ -51,7 +52,7 @@ contract NameRegistryGasUsageTest is Test {
         nameRegistryImpl = new NameRegistry(TRUSTED_FORWARDER);
         nameRegistryProxy = new ERC1967Proxy(address(nameRegistryImpl), "");
         nameRegistry = NameRegistry(address(nameRegistryProxy));
-        nameRegistry.initialize("Farcaster NameRegistry", "FCN", vault);
+        nameRegistry.initialize("Farcaster NameRegistry", "FCN", VAULT, POOL);
         nameRegistry.grantRole(ADMIN_ROLE, ADMIN);
     }
 

--- a/test/NameRegistryGasUsage.t.sol
+++ b/test/NameRegistryGasUsage.t.sol
@@ -13,12 +13,12 @@ contract NameRegistryGasUsageTest is Test {
     ERC1967Proxy nameRegistryProxy;
 
     address vault = address(this);
-    address owner = address(this);
 
     /*//////////////////////////////////////////////////////////////
                                 CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
+    address constant ADMIN = address(0xa6a4daBC320300cd0D38F77A6688C6b4048f4682);
     address constant TRUSTED_FORWARDER = address(0xC8223c8AD514A19Cc10B0C94c39b52D4B43ee61A);
     uint256 constant COMMIT_REGISTER_DELAY = 60;
 
@@ -41,6 +41,8 @@ contract NameRegistryGasUsageTest is Test {
         "jane1"
     ]; // padded to all be length 5
 
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTORS
     //////////////////////////////////////////////////////////////*/
@@ -50,10 +52,11 @@ contract NameRegistryGasUsageTest is Test {
         nameRegistryProxy = new ERC1967Proxy(address(nameRegistryImpl), "");
         nameRegistry = NameRegistry(address(nameRegistryProxy));
         nameRegistry.initialize("Farcaster NameRegistry", "FCN", vault);
+        nameRegistry.grantRole(ADMIN_ROLE, ADMIN);
     }
 
     function testGasUsage() public {
-        vm.prank(owner);
+        vm.prank(ADMIN);
         nameRegistry.disableTrustedRegister();
 
         // 1. During 2022, test making the commit and registering the name

--- a/test/NameRegistryUpgrade.t.sol
+++ b/test/NameRegistryUpgrade.t.sol
@@ -26,7 +26,7 @@ contract NameRegistryUpgradeTest is Test {
     address upgrader = address(0x456);
 
     address private constant FORWARDER = address(0xC8223c8AD514A19Cc10B0C94c39b52D4B43ee61A);
-    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
     function setUp() public {
         nameRegistry = new NameRegistry(FORWARDER);
@@ -35,7 +35,7 @@ contract NameRegistryUpgradeTest is Test {
 
         proxiedNameRegistry = NameRegistry(address(proxy));
         proxiedNameRegistry.initialize("Farcaster NameRegistry", "FCN", vault);
-        proxiedNameRegistry.grantRole(OWNER_ROLE, upgrader);
+        proxiedNameRegistry.grantRole(ADMIN_ROLE, upgrader);
     }
 
     function testInitializeSetters() public {


### PR DESCRIPTION
- add `withdraw` which allows the treasurer to move funds to the vault
- change `reclaim` to move names to a new pool address
- rename owner to admin in all tests
- refactor tests to separate admin from default admin 