### PR TITLE
feat(NameRegistry): trusted register should emit invite event

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,3 +1,4 @@
 IDRegistryGasUsageTest:testGasRegister() (gas: 800370)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedSender() (gas: 842391)
-NameRegistryGasUsageTest:testGasUsage() (gas: 2332670)
+NameRegistryGasUsageTest:testGasRegisterUsage() (gas: 2332147)
+NameRegistryGasUsageTest:testGasTrustedRegisterUsage() (gas: 1131307)

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -80,6 +80,8 @@ contract NameRegistry is
 
     event ChangeFee(uint256 fee);
 
+    event Invite(uint256 indexed inviterId, uint256 indexed inviteeId, bytes16 indexed username);
+
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -365,7 +367,9 @@ contract NameRegistry is
     function trustedRegister(
         address to,
         bytes16 username,
-        address recovery
+        address recovery,
+        uint256 inviter,
+        uint256 invitee
     ) external payable {
         /**
          *
@@ -390,6 +394,8 @@ contract NameRegistry is
         }
 
         recoveryOf[tokenId] = recovery;
+
+        emit Invite(inviter, invitee, username);
     }
 
     /**

--- a/test/NameRegistryGasUsage.t.sol
+++ b/test/NameRegistryGasUsage.t.sol
@@ -22,6 +22,8 @@ contract NameRegistryGasUsageTest is Test {
     address constant ADMIN = address(0xa6a4daBC320300cd0D38F77A6688C6b4048f4682);
     address constant TRUSTED_FORWARDER = address(0xC8223c8AD514A19Cc10B0C94c39b52D4B43ee61A);
     uint256 constant COMMIT_REGISTER_DELAY = 60;
+    address constant RECOVERY = address(0x456);
+    address constant TRUSTED_SENDER = address(0x123);
 
     uint256 constant DEC1_2022_TS = 1669881600; // Dec 1, 2022 00:00:00 GMT
     uint256 constant JAN1_2023_TS = 1672531200; // Jan 1, 2023 0:00:00 GMT
@@ -56,7 +58,7 @@ contract NameRegistryGasUsageTest is Test {
         nameRegistry.grantRole(ADMIN_ROLE, ADMIN);
     }
 
-    function testGasUsage() public {
+    function testGasRegisterUsage() public {
         vm.prank(ADMIN);
         nameRegistry.disableTrustedRegister();
 
@@ -79,12 +81,12 @@ contract NameRegistryGasUsageTest is Test {
             vm.warp(block.timestamp + COMMIT_REGISTER_DELAY);
             uint256 balance = alice.balance;
             vm.prank(alice);
-            nameRegistry.register{value: 0.01 ether}(name, alice, "secret", address(0x456));
+            nameRegistry.register{value: 0.01 ether}(name, alice, "secret", RECOVERY);
 
             assertEq(nameRegistry.ownerOf(nameTokenId), alice);
             assertEq(nameRegistry.expiryOf(nameTokenId), JAN1_2023_TS);
             assertEq(alice.balance, balance - nameRegistry.currYearFee());
-            assertEq(nameRegistry.recoveryOf(nameTokenId), address(0x456));
+            assertEq(nameRegistry.recoveryOf(nameTokenId), RECOVERY);
         }
 
         // 2. During 2023, test renewing the name after it expires. This must not be done in the previous
@@ -112,12 +114,12 @@ contract NameRegistryGasUsageTest is Test {
             vm.warp(JAN31_2024_TS);
 
             vm.prank(alice);
-            nameRegistry.bid{value: 1_000.01 ether}(nameTokenId, address(0x456));
+            nameRegistry.bid{value: 1_000.01 ether}(nameTokenId, RECOVERY);
 
             assertEq(nameRegistry.ownerOf(nameTokenId), alice);
             assertEq(nameRegistry.balanceOf(alice), 1);
             assertEq(nameRegistry.expiryOf(nameTokenId), JAN1_2025_TS);
-            assertEq(nameRegistry.recoveryOf(nameTokenId), address(0x456));
+            assertEq(nameRegistry.recoveryOf(nameTokenId), RECOVERY);
 
             vm.prank(alice);
             nameRegistry.transferFrom(alice, bob, nameTokenId);
@@ -125,6 +127,30 @@ contract NameRegistryGasUsageTest is Test {
             assertEq(nameRegistry.ownerOf(nameTokenId), bob);
             assertEq(nameRegistry.balanceOf(alice), 0);
             assertEq(nameRegistry.balanceOf(bob), 1);
+        }
+    }
+
+    function testGasTrustedRegisterUsage() public {
+        vm.prank(ADMIN);
+        nameRegistry.changeTrustedSender(TRUSTED_SENDER);
+
+        for (uint256 i = 0; i < names.length; i++) {
+            address alice = address(uint160(i) + 10); // start after the precompiles
+            bytes16 name = names[i];
+            uint256 nameTokenId = uint256(bytes32(name));
+
+            uint256 inviterId = 5;
+            uint256 inviteeId = 6;
+
+            vm.deal(alice, 10_000 ether);
+            vm.warp(DEC1_2022_TS);
+
+            vm.prank(TRUSTED_SENDER);
+            nameRegistry.trustedRegister(alice, name, RECOVERY, inviterId, inviteeId);
+
+            assertEq(nameRegistry.ownerOf(nameTokenId), alice);
+            assertEq(nameRegistry.expiryOf(nameTokenId), JAN1_2023_TS);
+            assertEq(nameRegistry.recoveryOf(nameTokenId), RECOVERY);
         }
     }
 }


### PR DESCRIPTION
The invite server should be able to pass the fids of the inviter and invitee into the trusted register method, which should in turn emit an on-chain invite event. 