### PR TITLE
fix(BundleRegistry): invitee should be automatically attributed

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,5 +1,5 @@
 BundleRegistryGasUsageTest:testGasRegister() (gas: 2103307)
-BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 1787080)
+BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 1795966)
 IDRegistryGasUsageTest:testGasRegister() (gas: 800469)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 838954)
 NameRegistryGasUsageTest:testGasRegisterUsage() (gas: 2332228)

--- a/src/BundleRegistry.sol
+++ b/src/BundleRegistry.sol
@@ -83,15 +83,14 @@ contract BundleRegistry is Ownable {
         address recovery,
         string calldata url,
         bytes16 username,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) external payable {
         // Do not allow anyone except the Farcaster Invite Server (trustedCaller) to call this
         if (msg.sender != trustedCaller) revert Unauthorized();
 
         // Audit: is it possible to end up in a state where one passes but the other fails?
         idRegistry.trustedRegister(to, recovery, url);
-        nameRegistry.trustedRegister(username, to, recovery, inviter, invitee);
+        nameRegistry.trustedRegister(username, to, recovery, inviter, idRegistry.idOf(to));
     }
 
     /**
@@ -104,15 +103,14 @@ contract BundleRegistry is Ownable {
         address recovery,
         string calldata url,
         bytes16 username,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) external payable {
         // Do not allow anyone except the Farcaster Invite Server (trustedCaller) to call this
         if (msg.sender != trustedCaller) revert Unauthorized();
 
         // Audit: is it possible to end up in a state where one passes but the other fails?
         idRegistry.register(to, recovery, url);
-        nameRegistry.trustedRegister(username, to, recovery, inviter, invitee);
+        nameRegistry.trustedRegister(username, to, recovery, inviter, idRegistry.idOf(to));
     }
 
     /**

--- a/test/BundleRegistry.t.sol
+++ b/test/BundleRegistry.t.sol
@@ -21,6 +21,7 @@ contract BundleRegistryTest is Test {
     ERC1967Proxy nameRegistryProxy;
 
     event ChangeTrustedCaller(address indexed trustedCaller, address indexed owner);
+    event Invite(uint256 indexed inviterId, uint256 indexed inviteeId, bytes16 indexed fname);
 
     /*//////////////////////////////////////////////////////////////
                                 CONSTANTS
@@ -213,8 +214,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -224,7 +224,9 @@ contract BundleRegistryTest is Test {
         vm.prank(ADMIN);
         nameRegistry.changeTrustedCaller(address(bundleRegistry));
 
-        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        vm.expectEmit(true, true, true, true);
+        emit Invite(inviter, 1, "alice");
+        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertSuccessfulRegistration(alice, recovery);
     }
@@ -234,7 +236,6 @@ contract BundleRegistryTest is Test {
         address recovery,
         string calldata url,
         uint256 inviter,
-        uint256 invitee,
         address untrustedCaller
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
@@ -250,7 +251,7 @@ contract BundleRegistryTest is Test {
         // and therefore the trusted caller for BundleRegistry
         vm.prank(untrustedCaller);
         vm.expectRevert(BundleRegistry.Unauthorized.selector);
-        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -259,8 +260,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -272,7 +272,7 @@ contract BundleRegistryTest is Test {
         idRegistry.disableTrustedOnly();
 
         vm.expectRevert(NameRegistry.Registrable.selector);
-        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -281,8 +281,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -294,7 +293,7 @@ contract BundleRegistryTest is Test {
         nameRegistry.disableTrustedOnly();
 
         vm.expectRevert(NameRegistry.NotInvitable.selector);
-        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -303,8 +302,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -315,7 +313,7 @@ contract BundleRegistryTest is Test {
         nameRegistry.disableTrustedOnly();
 
         vm.expectRevert(NameRegistry.Registrable.selector);
-        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.trustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -328,8 +326,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -340,7 +337,9 @@ contract BundleRegistryTest is Test {
         nameRegistry.changeTrustedCaller(address(bundleRegistry));
         idRegistry.disableTrustedOnly();
 
-        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        vm.expectEmit(true, true, true, true);
+        emit Invite(inviter, 1, "alice");
+        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertSuccessfulRegistration(alice, recovery);
     }
@@ -349,8 +348,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -361,7 +359,7 @@ contract BundleRegistryTest is Test {
         nameRegistry.changeTrustedCaller(address(bundleRegistry));
 
         vm.expectRevert(IDRegistry.Invitable.selector);
-        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -370,8 +368,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -383,7 +380,7 @@ contract BundleRegistryTest is Test {
         nameRegistry.disableTrustedOnly();
 
         vm.expectRevert(IDRegistry.Invitable.selector);
-        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -392,8 +389,7 @@ contract BundleRegistryTest is Test {
         address alice,
         address recovery,
         string calldata url,
-        uint256 inviter,
-        uint256 invitee
+        uint256 inviter
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
         vm.warp(DEC1_2022_TS); // Block timestamp must be >= 2022 to call the NameRegistry
@@ -404,7 +400,7 @@ contract BundleRegistryTest is Test {
         nameRegistry.disableTrustedOnly();
 
         vm.expectRevert(NameRegistry.NotInvitable.selector);
-        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }
@@ -414,7 +410,6 @@ contract BundleRegistryTest is Test {
         address recovery,
         string calldata url,
         uint256 inviter,
-        uint256 invitee,
         address untrustedCaller
     ) public {
         vm.assume(alice != address(0)); // OZ's ERC-721 throws when a zero-address mints an NFT
@@ -431,7 +426,7 @@ contract BundleRegistryTest is Test {
         // deployer and therefore the trusted caller for BundleRegistry
         vm.prank(untrustedCaller);
         vm.expectRevert(BundleRegistry.Unauthorized.selector);
-        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter, invitee);
+        bundleRegistry.partialTrustedRegister(alice, recovery, url, "alice", inviter);
 
         _assertUnsuccessfulRegistration(alice);
     }

--- a/test/BundleRegistryGasUsage.t.sol
+++ b/test/BundleRegistryGasUsage.t.sol
@@ -107,7 +107,7 @@ contract BundleRegistryGasUsageTest is Test {
 
             // 3. Register the name alice
             vm.warp(block.timestamp + 60 seconds);
-            bundleRegistry.trustedRegister(alice, RECOVERY, URL, name, 1, 2);
+            bundleRegistry.trustedRegister(alice, RECOVERY, URL, name, 1);
 
             assertEq(nameRegistry.ownerOf(nameTokenId), alice);
             assertEq(nameRegistry.expiryOf(nameTokenId), JAN1_2023_TS);


### PR DESCRIPTION
Previously, BundleRegistry's `trustedRegister` and `partialTrustedRegister` required passing in the invitee for the Invite event. However, this is only known after calling IDRegistry during the call and cannot be provided ahead of time. This change no longer requires the parameter to be provided and populates it automatically. 

There are two ways this could have been implemented: 

1. Modifying IDRegistry's `register` and `trustedRegister` to return the id
2. Query the IDRegistry's idOf function between calls to fetch the id 


Option 1 was rejected because it added a fixed ~150 gas cost to all register calls for all time, while Option 2 only added ~800 gas to calls made during the invitation period.  While Option 1 adds greater composability for future actions that might want to do things with the id immediately after registration, those use cases are less clear and so Option 2 was selected instead. 

