### PR TITLE
feat: add precommit hook to check if gas snapshots are up to date

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+forge snapshot --check --match-contract Gas


### PR DESCRIPTION
addresses #48 

Question: I noticed the CI is running "--match-contract Gas" which I have included here to keep it in line with the expected results. I see that we also have some tests that are specifically related to Gas usage. Is there a downside to running the snapshot for all tests? 