### PR TITLE
perf(NameRegistry): check for overpayment before returning funds

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,6 +1,6 @@
-BundleRegistryGasUsageTest:testGasRegister() (gas: 1883943)
+BundleRegistryGasUsageTest:testGasRegister() (gas: 1881503)
 BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 1748097)
 IDRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 2077004)
 IDRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 838954)
-NameRegistryGasUsageTest:testGasRegister() (gas: 2123149)
+NameRegistryGasUsageTest:testGasRegister() (gas: 2118613)
 NameRegistryGasUsageTest:testGasTrustedRegister() (gas: 1123092)

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -448,12 +448,17 @@ contract NameRegistry is
 
         recoveryOf[tokenId] = recovery;
 
+        uint256 overpayment;
+
         unchecked {
             // Safety: msg.value >= _fee by check above, so this cannot overflow
+            overpayment = msg.value - _fee;
+        }
 
+        if (overpayment > 0) {
             // Perf: Call msg.sender instead of _msgSender() to save ~100 gas b/c we don't need meta-tx
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = msg.sender.call{value: msg.value - _fee}("");
+            (bool success, ) = msg.sender.call{value: overpayment}("");
             if (!success) revert CallFailed();
         }
     }
@@ -525,12 +530,17 @@ contract NameRegistry is
 
         emit Renew(tokenId, expiryOf[tokenId]);
 
+        uint256 overpayment;
+
         unchecked {
             // Safety: msg.value >= _fee by check above, so this cannot overflow
+            overpayment = msg.value - _fee;
+        }
 
+        if (overpayment > 0) {
             // Perf: Call msg.sender instead of _msgSender() to save ~100 gas b/c we don't need meta-tx
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = msg.sender.call{value: msg.value - _fee}("");
+            (bool success, ) = msg.sender.call{value: overpayment}("");
             if (!success) revert CallFailed();
         }
     }
@@ -625,12 +635,17 @@ contract NameRegistry is
 
         recoveryOf[tokenId] = recovery;
 
+        uint256 overpayment;
+
         unchecked {
             // Safety: msg.value >= price by check above, so this cannot underflow
+            overpayment = msg.value - price;
+        }
 
+        if (overpayment > 0) {
             // Perf: Call msg.sender instead of _msgSender() to save ~100 gas b/c we don't need meta-tx
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = msg.sender.call{value: msg.value - price}("");
+            (bool success, ) = msg.sender.call{value: overpayment}("");
             if (!success) revert CallFailed();
         }
     }


### PR DESCRIPTION
Since the payment for bid, renew and register are now predictable overpayments will be unlikely. Save gas by checking if there is an overpayment before returning the funds. 

- register costs 151 less
- renew costs 189 less
- bid costs 151 less


Thanks to [@ncitron](https://github.com/ncitron), Matt Gleason, and [@blauyourmind](https://github.com/Blauyourmind) for identifying this.