### PR TITLE
Correct comment explaining `trustedOnly`

### DIFF
--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -138,7 +138,7 @@ contract IdRegistry is ERC2771Context, Ownable {
     address internal pendingOwner;
 
     /**
-     * @dev Allows calling trustedRegister() when set 0, and register() when set to 1. The value is
+     * @dev Allows calling trustedRegister() when set 1, and register() when set to 0. The value is
      *      set to 1 and can be changed to 0, but never back to 1.
      */
     uint256 internal trustedOnly = 1;


### PR DESCRIPTION
In `register`:
https://github.com/farcasterxyz/contracts/blob/80dde9b16ba09774d7500e24cded5fd88a71863e/src/IdRegistry.sol#L200

and, in `trustedRegister`:
https://github.com/farcasterxyz/contracts/blob/80dde9b16ba09774d7500e24cded5fd88a71863e/src/IdRegistry.sol#L223

=> `trustedOnly = 0` to call `register`.
`trustedOnly = 1` to call `trustedRegister`.

The comment over the the definition of `trustedOnly` conveyed the opposite.
https://github.com/farcasterxyz/contracts/blob/80dde9b16ba09774d7500e24cded5fd88a71863e/src/IdRegistry.sol#L141

Cheers,
Yash Karthik