### PR TITLE
fix: exclude known contracts to prevent fuzzer false positives

### DIFF
--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -46,7 +46,10 @@ contract NameRegistryTest is Test {
         address(0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84), // address(this)
         address(0xC8223c8AD514A19Cc10B0C94c39b52D4B43ee61A), // FORWARDER
         address(0x185a4dc360CE69bDCceE33b3784B0282f7961aea), // ???
-        address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D) // ???
+        address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D), // ???
+        address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f), // ???
+        address(0x2e234DAe75C793f67A35089C9d99245E1C58470b), // ???
+        address(0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496) // ???
     ];
 
     // Address of the last precompile contract


### PR DESCRIPTION
## Motivation

A few new "known contracts" have been causing fuzzer failures

## Change Summary

Added addresses of 3 new known contracts to fuzzer exclusion list

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)