### PR TITLE
test: Add some timestamp fuzzing to test coverage

### DIFF
--- a/test/TestConstants.sol
+++ b/test/TestConstants.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.16;
+
+// When fuzzing, concern ourselves with functionality for the next 100 years
+uint256 constant FUZZ_TIME_PERIOD = 100 * 365.25 days;


### PR DESCRIPTION
BundleRegistry#testCannotRegisterIfIdRegistryEnabledNameRegistryDisabled BundleRegistry#testRegister
IdRegistry#testCancelRecoveryFromCustodyAddress
IdRegistry#testCancelRecoveryFromRecoveryAddress
IdRegistry#testCannotCompleteRecoveryIfNotRequested IdRegistry#testCannotCompleteRecoveryToAddressThatOwnsAnId IdRegistry#testRequestRecoveryOverridesPreviousRecovery IdRegistyry#testCompleteRecovery
NameRegistry#testCannotRegisterTheSameNameAgain
NameRegistry#testMakeCommitAfterReplayDelay
NameRegistry#testRegister
NameRegistry#testRegisterAfterUnpausing
NameRegistry#testRegisterWorksWhenAlreadyOwningAName

## Motivation

Fuzzing timestamps adds test coverage to ensure functionality is not inadvertently making assumptions.

## Change Summary

Added some timestamp fuzzing to the tests.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


