### PR TITLE
feat: allow reclaiming multiple usernames

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,6 +1,6 @@
-BundleRegistryGasUsageTest:testGasRegister() (gas: 1882701)
+BundleRegistryGasUsageTest:testGasRegister() (gas: 1882723)
 BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 1748537)
 IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 2081451)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 840128)
-NameRegistryGasUsageTest:testGasRegister() (gas: 2119544)
+NameRegistryGasUsageTest:testGasRegister() (gas: 2120090)
 NameRegistryGasUsageTest:testGasTrustedRegister() (gas: 1122616)

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -926,7 +926,7 @@ contract NameRegistry is
      * @param reclaimActions an array of ReclaimAction structs representing the fnames and their corresponding
      *           destination addresses.
      */
-    function recl(ReclaimAction[] calldata reclaimActions) external payable {
+    function reclaim(ReclaimAction[] calldata reclaimActions) external payable {
         // call msg.sender instead of _msgSender() since we don't need meta-tx for admin actions
         // and it reduces our attack surface area
         if (!hasRole(MODERATOR_ROLE, msg.sender)) revert NotModerator();

--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -34,6 +34,16 @@ contract NameRegistry is
 {
     using FixedPointMathLib for uint256;
 
+    /**
+     * @dev ReclaimAction struct represents the necessary information for a moderator to reclaim an fname.
+     * @param tokenId The uint256 representation of the fname.
+     * @param destination The address that the fname can be reclaimed to.
+     */
+    struct ReclaimAction {
+        uint256 tokenId;
+        address destination;
+    }
+
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2887,6 +2887,72 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
     }
 
+    function testReclaimMultipleBiddableNames(
+        address[4] calldata users,
+        address mod,
+        address recovery,
+        address[4] calldata destinations
+    ) public {
+        _assumeClean(mod);
+        _assumeClean(recovery);
+        address[] memory addresses = new address[](10);
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+        }
+        addresses[8] = mod;
+        addresses[9] = recovery;
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
+        uint256 biddableTs = block.timestamp + REGISTRATION_PERIOD + RENEWAL_PERIOD;
+        _grant(MODERATOR_ROLE, ADMIN);
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _requestRecovery(users[i], tokenIds[i], recovery);
+        }
+
+        vm.warp(biddableTs);
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+            vm.expectEmit(true, true, true, true);
+            emit Transfer(users[i], destinations[i], tokenIds[i]);
+        }
+        vm.prank(ADMIN);
+        nameRegistry.reclaim(reclaimActions);
+
+        // reclaim should extend the expiry ahead of the current timestamp
+        uint256 expectedExpiryTs = block.timestamp + RENEWAL_PERIOD;
+
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.balanceOf(users[i]), 0);
+            assertEq(nameRegistry.balanceOf(destinations[i]), 1);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), expectedExpiryTs);
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), destinations[i]);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), 0);
+        }
+    }
+
     function testReclaimResetsERC721Approvals(address alice, address bob) public {
         _assumeClean(alice);
         _assumeClean(bob);

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2972,14 +2972,17 @@ contract NameRegistryTest is Test {
 
     function testReclaimMultipleResetsERC721Approvals(
         address[4] calldata users,
-        address[4] calldata approveUsers
+        address[4] calldata approveUsers,
+        address[4] calldata destinations
     ) public {
-        address[] memory addresses = new address[](8);
+        address[] memory addresses = new address[](12);
         for (uint256 i = 0; i < users.length; i++) {
             _assumeClean(users[i]);
             _assumeClean(approveUsers[i]);
+            _assumeClean(destinations[i]);
             addresses[i] = users[i];
             addresses[i + 4] = approveUsers[i];
+            addresses[i + 8] = destinations[i];
         }
         _assumeUnique(addresses);
 
@@ -3009,7 +3012,7 @@ contract NameRegistryTest is Test {
         NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
 
         for (uint256 i = 0; i < users.length; i++) {
-            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], POOL);
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
         }
         vm.prank(ADMIN);
         nameRegistry.reclaim(reclaimActions);
@@ -3036,6 +3039,54 @@ contract NameRegistryTest is Test {
 
         assertEq(nameRegistry.ownerOf(ALICE_TOKEN_ID), alice);
         assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), renewableTs);
+    }
+
+    function testReclaimMultipleWhenPaused(address[4] calldata users, address[4] calldata destinations) public {
+        address[] memory addresses = new address[](8);
+        for (uint256 i = 0; i < users.length; i++) {
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+        }
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+        uint256 renewableTs = block.timestamp + REGISTRATION_PERIOD;
+
+        _grant(MODERATOR_ROLE, ADMIN);
+        _grant(OPERATOR_ROLE, ADMIN);
+
+        vm.prank(ADMIN);
+        nameRegistry.pause();
+
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+        }
+        vm.prank(ADMIN);
+        vm.expectRevert("Pausable: paused");
+        nameRegistry.reclaim(reclaimActions);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), users[i]);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), renewableTs);
+        }
     }
 
     function testCannotReclaimIfRegistrable(address mod) public {

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2970,6 +2970,55 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.getApproved(ALICE_TOKEN_ID), address(0));
     }
 
+    function testReclaimMultipleResetsERC721Approvals(
+        address[4] calldata users,
+        address[4] calldata approveUsers
+    ) public {
+        address[] memory addresses = new address[](8);
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(approveUsers[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = approveUsers[i];
+        }
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
+        _grant(MODERATOR_ROLE, ADMIN);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            vm.prank(users[i]);
+            nameRegistry.approve(approveUsers[i], tokenIds[i]);
+        }
+
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], POOL);
+        }
+        vm.prank(ADMIN);
+        nameRegistry.reclaim(reclaimActions);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.getApproved(tokenIds[i]), address(0));
+        }
+    }
+
     function testReclaimWhenPaused(address alice) public {
         _assumeClean(alice);
         _register(alice);

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2159,7 +2159,9 @@ contract NameRegistryTest is Test {
         nameRegistry.completeRecovery(ALICE_TOKEN_ID);
 
         assertEq(nameRegistry.balanceOf(alice), 1);
-        if (alice != notRecovery) assertEq(nameRegistry.balanceOf(notRecovery), 0);
+        if (alice != notRecovery) {
+            assertEq(nameRegistry.balanceOf(notRecovery), 0);
+        }
         assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), renewableTs);
         assertEq(nameRegistry.ownerOf(ALICE_TOKEN_ID), alice);
         assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), recovery);
@@ -3103,6 +3105,42 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), 0);
         assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), address(0));
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
+    }
+
+    function testCannotReclaimMultipleIfRegistrable(address mod, address[4] calldata destinations) public {
+        _assumeClean(mod);
+        address[] memory addresses = new address[](4);
+        for (uint256 i = 0; i < destinations.length; i++) {
+            _assumeClean(destinations[i]);
+            addresses[i] = destinations[i];
+        }
+        _assumeUnique(addresses);
+        _grant(MODERATOR_ROLE, mod);
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+        }
+
+        vm.prank(mod);
+        vm.expectRevert(NameRegistry.Registrable.selector);
+        nameRegistry.reclaim(reclaimActions);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            assertEq(nameRegistry.balanceOf(destinations[i]), 0);
+            vm.expectRevert("ERC721: invalid token ID");
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), 0);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), 0);
+        }
     }
 
     function testCannotReclaimUnlessModerator(address alice, address notModerator, address recovery) public {

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2614,20 +2614,20 @@ contract NameRegistryTest is Test {
     function testReclaimMultipleRegisteredNames(
         address[4] calldata users,
         address mod,
-        address recovery,
+        address[4] calldata recoveryAddresses,
         address[4] calldata destinations
     ) public {
         _assumeClean(mod);
-        _assumeClean(recovery);
-        address[] memory addresses = new address[](10);
+        address[] memory addresses = new address[](13);
         for (uint256 i = 0; i < users.length; i++) {
             _assumeClean(users[i]);
             _assumeClean(destinations[i]);
+            _assumeClean(recoveryAddresses[i]);
             addresses[i] = users[i];
             addresses[i + 4] = destinations[i];
+            addresses[i + 8] = recoveryAddresses[i];
         }
-        addresses[8] = mod;
-        addresses[9] = recovery;
+        addresses[12] = mod;
         _assumeUnique(addresses);
 
         bytes16[] memory fnames = new bytes16[](4);
@@ -2650,7 +2650,7 @@ contract NameRegistryTest is Test {
         _grant(MODERATOR_ROLE, mod);
 
         for (uint256 i = 0; i < fnames.length; i++) {
-            _requestRecovery(users[i], tokenIds[i], recovery);
+            _requestRecovery(users[i], tokenIds[i], recoveryAddresses[i]);
         }
 
         NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
@@ -3109,11 +3109,12 @@ contract NameRegistryTest is Test {
 
     function testCannotReclaimMultipleIfRegistrable(address mod, address[4] calldata destinations) public {
         _assumeClean(mod);
-        address[] memory addresses = new address[](4);
+        address[] memory addresses = new address[](5);
         for (uint256 i = 0; i < destinations.length; i++) {
             _assumeClean(destinations[i]);
             addresses[i] = destinations[i];
         }
+        addresses[4] = mod;
         _assumeUnique(addresses);
         _grant(MODERATOR_ROLE, mod);
 
@@ -3162,6 +3163,67 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), renewableTs);
         assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), recovery);
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), recoveryTs);
+    }
+
+    function testCannotReclaimMultipleUnlessModerator(
+        address[4] calldata users,
+        address[4] calldata destinations,
+        address notModerator,
+        address[4] calldata recoveryAddresses
+    ) public {
+        _assumeClean(notModerator);
+        address[] memory addresses = new address[](13);
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+            _assumeClean(recoveryAddresses[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+            addresses[i + 8] = recoveryAddresses[i];
+        }
+        addresses[12] = notModerator;
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
+        uint256 renewableTs = block.timestamp + REGISTRATION_PERIOD;
+        uint256 recoveryTs;
+        for (uint256 i = 0; i < fnames.length; i++) {
+            recoveryTs = _requestRecovery(users[i], tokenIds[i], recoveryAddresses[i]);
+        }
+
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+        }
+
+        vm.prank(notModerator);
+        vm.expectRevert(NameRegistry.NotModerator.selector);
+        nameRegistry.reclaim(reclaimActions);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            assertEq(nameRegistry.balanceOf(users[i]), 1);
+            assertEq(nameRegistry.balanceOf(destinations[i]), 0);
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), users[i]);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), renewableTs);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), recoveryAddresses[i]);
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), recoveryTs);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -76,6 +76,8 @@ contract NameRegistryTest is Test {
 
     uint256 constant ALICE_TOKEN_ID = uint256(bytes32("alice"));
     uint256 constant BOB_TOKEN_ID = uint256(bytes32("bob"));
+    uint256 constant CAROL_TOKEN_ID = uint256(bytes32("carol"));
+    uint256 constant DAN_TOKEN_ID = uint256(bytes32("dan"));
 
     bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
     bytes32 constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
@@ -2607,6 +2609,97 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
     }
 
+    function testReclaimMultipleRegisteredName(
+        address alice,
+        address bob,
+        address carol,
+        address dan,
+        address mod,
+        address recovery,
+        address destination1,
+        address destination2,
+        address destination3,
+        address destination4
+    ) public {
+        _assumeClean(alice);
+        _assumeClean(bob);
+        _assumeClean(carol);
+        _assumeClean(dan);
+        _assumeClean(mod);
+        _assumeClean(recovery);
+        _assumeClean(destination1);
+        _assumeClean(destination2);
+        _assumeClean(destination3);
+        _assumeClean(destination4);
+        address[] memory addresses = new address[](10);
+        addresses[0] = alice;
+        addresses[1] = bob;
+        addresses[2] = carol;
+        addresses[3] = dan;
+        addresses[4] = mod;
+        addresses[5] = recovery;
+        addresses[6] = destination1;
+        addresses[7] = destination2;
+        addresses[8] = destination3;
+        addresses[9] = destination4;
+        _assumeUnique(addresses);
+
+        _register(alice);
+        _register(bob, "bob");
+        _register(carol, "carol");
+        _register(dan, "dan");
+        uint256 renewalTs = block.timestamp + REGISTRATION_PERIOD;
+        _grant(MODERATOR_ROLE, mod);
+        _requestRecovery(alice, recovery);
+        _requestRecovery(bob, BOB_TOKEN_ID, recovery);
+        _requestRecovery(carol, CAROL_TOKEN_ID, recovery);
+        _requestRecovery(dan, DAN_TOKEN_ID, recovery);
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, destination1, ALICE_TOKEN_ID);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(bob, destination2, BOB_TOKEN_ID);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(carol, destination3, CAROL_TOKEN_ID);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(dan, destination4, DAN_TOKEN_ID);
+        vm.prank(mod);
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+        reclaimActions[0] = NameRegistry.ReclaimAction(ALICE_TOKEN_ID, destination1);
+        reclaimActions[1] = NameRegistry.ReclaimAction(BOB_TOKEN_ID, destination2);
+        reclaimActions[2] = NameRegistry.ReclaimAction(CAROL_TOKEN_ID, destination3);
+        reclaimActions[3] = NameRegistry.ReclaimAction(DAN_TOKEN_ID, destination4);
+        nameRegistry.reclaim(reclaimActions);
+
+        assertEq(nameRegistry.balanceOf(alice), 0);
+        assertEq(nameRegistry.balanceOf(destination1), 1);
+        assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), renewalTs);
+        assertEq(nameRegistry.ownerOf(ALICE_TOKEN_ID), destination1);
+        assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), address(0));
+        assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
+
+        assertEq(nameRegistry.balanceOf(bob), 0);
+        assertEq(nameRegistry.balanceOf(destination2), 1);
+        assertEq(nameRegistry.expiryOf(BOB_TOKEN_ID), renewalTs);
+        assertEq(nameRegistry.ownerOf(BOB_TOKEN_ID), destination2);
+        assertEq(nameRegistry.recoveryOf(BOB_TOKEN_ID), address(0));
+        assertEq(nameRegistry.recoveryClockOf(BOB_TOKEN_ID), 0);
+
+        assertEq(nameRegistry.balanceOf(carol), 0);
+        assertEq(nameRegistry.balanceOf(destination3), 1);
+        assertEq(nameRegistry.expiryOf(CAROL_TOKEN_ID), renewalTs);
+        assertEq(nameRegistry.ownerOf(CAROL_TOKEN_ID), destination3);
+        assertEq(nameRegistry.recoveryOf(CAROL_TOKEN_ID), address(0));
+        assertEq(nameRegistry.recoveryClockOf(CAROL_TOKEN_ID), 0);
+
+        assertEq(nameRegistry.balanceOf(dan), 0);
+        assertEq(nameRegistry.balanceOf(destination4), 1);
+        assertEq(nameRegistry.expiryOf(DAN_TOKEN_ID), renewalTs);
+        assertEq(nameRegistry.ownerOf(DAN_TOKEN_ID), destination4);
+        assertEq(nameRegistry.recoveryOf(DAN_TOKEN_ID), address(0));
+        assertEq(nameRegistry.recoveryClockOf(DAN_TOKEN_ID), 0);
+    }
+
     function testReclaimRegisteredNameCloseToExpiryShouldExtend(address alice, address mod, address recovery) public {
         _assumeClean(alice);
         _assumeClean(mod);
@@ -2983,6 +3076,22 @@ contract NameRegistryTest is Test {
         vm.stopPrank();
     }
 
+    /// @dev Register the username to the user address on Jan 1, 2023
+    function _register(address user, bytes16 username) internal {
+        _disableTrusted();
+
+        vm.deal(user, 10_000 ether);
+        vm.warp(JAN1_2023_TS);
+
+        vm.startPrank(user);
+        bytes32 commitHash = nameRegistry.generateCommit(username, user, "secret", address(0));
+        nameRegistry.makeCommit(commitHash);
+        vm.warp(block.timestamp + COMMIT_REVEAL_DELAY);
+
+        nameRegistry.register{value: nameRegistry.fee()}(username, user, "secret", address(0));
+        vm.stopPrank();
+    }
+
     /// @dev vm.assume that the address does not match known contracts
     function _assumeClean(address a) internal {
         for (uint256 i = 0; i < knownContracts.length; i++) {
@@ -2991,6 +3100,15 @@ contract NameRegistryTest is Test {
 
         vm.assume(a > MAX_PRECOMPILE);
         vm.assume(a != ADMIN);
+    }
+
+    /// @dev vm.assume that the address are unique
+    function _assumeUnique(address[] memory addresses) internal {
+        for (uint256 i = 0; i < addresses.length - 1; i++) {
+            for (uint256 j = i + 1; j < addresses.length; j++) {
+                vm.assume(addresses[i] != addresses[j]);
+            }
+        }
     }
 
     /// @dev Helper that assigns the recovery address and then requests a recovery
@@ -3004,6 +3122,20 @@ contract NameRegistryTest is Test {
         nameRegistry.requestRecovery(ALICE_TOKEN_ID, recovery);
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), block.timestamp);
         assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), recovery);
+        return block.timestamp;
+    }
+
+    /// @dev Helper that assigns the recovery address and then requests a recovery
+    function _requestRecovery(address user, uint256 tokenId, address recovery) internal returns (uint256 requestTs) {
+        vm.prank(user);
+        nameRegistry.changeRecoveryAddress(tokenId, recovery);
+        assertEq(nameRegistry.recoveryOf(tokenId), recovery);
+        assertEq(nameRegistry.recoveryClockOf(tokenId), 0);
+
+        vm.prank(recovery);
+        nameRegistry.requestRecovery(tokenId, recovery);
+        assertEq(nameRegistry.recoveryClockOf(tokenId), block.timestamp);
+        assertEq(nameRegistry.recoveryOf(tokenId), recovery);
         return block.timestamp;
     }
 

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2794,6 +2794,72 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
     }
 
+    function testReclaimMultipleExpiredNames(
+        address[4] calldata users,
+        address mod,
+        address recovery,
+        address[4] calldata destinations
+    ) public {
+        _assumeClean(mod);
+        _assumeClean(recovery);
+        address[] memory addresses = new address[](10);
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+        }
+        addresses[8] = mod;
+        addresses[9] = recovery;
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
+        uint256 renewableTs = block.timestamp + REGISTRATION_PERIOD;
+        _grant(MODERATOR_ROLE, mod);
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _requestRecovery(users[i], tokenIds[i], recovery);
+        }
+
+        vm.warp(renewableTs);
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+            vm.expectEmit(true, true, true, true);
+            emit Transfer(users[i], destinations[i], tokenIds[i]);
+        }
+        vm.prank(mod);
+        nameRegistry.reclaim(reclaimActions);
+
+        // reclaim should extend the expiry ahead of the current timestamp
+        uint256 expectedExpiryTs = block.timestamp + RENEWAL_PERIOD;
+
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.balanceOf(users[i]), 0);
+            assertEq(nameRegistry.balanceOf(destinations[i]), 1);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), expectedExpiryTs);
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), destinations[i]);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), 0);
+        }
+    }
+
     function testReclaimBiddableNames(address alice, address mod, address recovery) public {
         _assumeClean(alice);
         _assumeClean(mod);

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2610,94 +2610,66 @@ contract NameRegistryTest is Test {
     }
 
     function testReclaimMultipleRegisteredName(
-        address alice,
-        address bob,
-        address carol,
-        address dan,
+        address[4] calldata users,
         address mod,
         address recovery,
-        address destination1,
-        address destination2,
-        address destination3,
-        address destination4
+        address[4] calldata destinations
     ) public {
-        _assumeClean(alice);
-        _assumeClean(bob);
-        _assumeClean(carol);
-        _assumeClean(dan);
         _assumeClean(mod);
         _assumeClean(recovery);
-        _assumeClean(destination1);
-        _assumeClean(destination2);
-        _assumeClean(destination3);
-        _assumeClean(destination4);
         address[] memory addresses = new address[](10);
-        addresses[0] = alice;
-        addresses[1] = bob;
-        addresses[2] = carol;
-        addresses[3] = dan;
-        addresses[4] = mod;
-        addresses[5] = recovery;
-        addresses[6] = destination1;
-        addresses[7] = destination2;
-        addresses[8] = destination3;
-        addresses[9] = destination4;
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+        }
+        addresses[8] = mod;
+        addresses[9] = recovery;
         _assumeUnique(addresses);
 
-        _register(alice);
-        _register(bob, "bob");
-        _register(carol, "carol");
-        _register(dan, "dan");
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
         uint256 renewalTs = block.timestamp + REGISTRATION_PERIOD;
         _grant(MODERATOR_ROLE, mod);
-        _requestRecovery(alice, recovery);
-        _requestRecovery(bob, BOB_TOKEN_ID, recovery);
-        _requestRecovery(carol, CAROL_TOKEN_ID, recovery);
-        _requestRecovery(dan, DAN_TOKEN_ID, recovery);
 
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, destination1, ALICE_TOKEN_ID);
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(bob, destination2, BOB_TOKEN_ID);
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(carol, destination3, CAROL_TOKEN_ID);
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(dan, destination4, DAN_TOKEN_ID);
-        vm.prank(mod);
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _requestRecovery(users[i], tokenIds[i], recovery);
+        }
+
         NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
-        reclaimActions[0] = NameRegistry.ReclaimAction(ALICE_TOKEN_ID, destination1);
-        reclaimActions[1] = NameRegistry.ReclaimAction(BOB_TOKEN_ID, destination2);
-        reclaimActions[2] = NameRegistry.ReclaimAction(CAROL_TOKEN_ID, destination3);
-        reclaimActions[3] = NameRegistry.ReclaimAction(DAN_TOKEN_ID, destination4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+            vm.expectEmit(true, true, true, true);
+            emit Transfer(users[i], destinations[i], tokenIds[i]);
+        }
+
+        vm.prank(mod);
         nameRegistry.reclaim(reclaimActions);
 
-        assertEq(nameRegistry.balanceOf(alice), 0);
-        assertEq(nameRegistry.balanceOf(destination1), 1);
-        assertEq(nameRegistry.expiryOf(ALICE_TOKEN_ID), renewalTs);
-        assertEq(nameRegistry.ownerOf(ALICE_TOKEN_ID), destination1);
-        assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), address(0));
-        assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
-
-        assertEq(nameRegistry.balanceOf(bob), 0);
-        assertEq(nameRegistry.balanceOf(destination2), 1);
-        assertEq(nameRegistry.expiryOf(BOB_TOKEN_ID), renewalTs);
-        assertEq(nameRegistry.ownerOf(BOB_TOKEN_ID), destination2);
-        assertEq(nameRegistry.recoveryOf(BOB_TOKEN_ID), address(0));
-        assertEq(nameRegistry.recoveryClockOf(BOB_TOKEN_ID), 0);
-
-        assertEq(nameRegistry.balanceOf(carol), 0);
-        assertEq(nameRegistry.balanceOf(destination3), 1);
-        assertEq(nameRegistry.expiryOf(CAROL_TOKEN_ID), renewalTs);
-        assertEq(nameRegistry.ownerOf(CAROL_TOKEN_ID), destination3);
-        assertEq(nameRegistry.recoveryOf(CAROL_TOKEN_ID), address(0));
-        assertEq(nameRegistry.recoveryClockOf(CAROL_TOKEN_ID), 0);
-
-        assertEq(nameRegistry.balanceOf(dan), 0);
-        assertEq(nameRegistry.balanceOf(destination4), 1);
-        assertEq(nameRegistry.expiryOf(DAN_TOKEN_ID), renewalTs);
-        assertEq(nameRegistry.ownerOf(DAN_TOKEN_ID), destination4);
-        assertEq(nameRegistry.recoveryOf(DAN_TOKEN_ID), address(0));
-        assertEq(nameRegistry.recoveryClockOf(DAN_TOKEN_ID), 0);
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.balanceOf(users[i]), 0);
+            assertEq(nameRegistry.balanceOf(destinations[i]), 1);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), renewalTs);
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), destinations[i]);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), 0);
+        }
     }
 
     function testReclaimRegisteredNameCloseToExpiryShouldExtend(address alice, address mod, address recovery) public {

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -2609,7 +2609,7 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
     }
 
-    function testReclaimMultipleRegisteredName(
+    function testReclaimMultipleRegisteredNames(
         address[4] calldata users,
         address mod,
         address recovery,
@@ -2698,6 +2698,73 @@ contract NameRegistryTest is Test {
         assertEq(nameRegistry.ownerOf(ALICE_TOKEN_ID), POOL);
         assertEq(nameRegistry.recoveryOf(ALICE_TOKEN_ID), address(0));
         assertEq(nameRegistry.recoveryClockOf(ALICE_TOKEN_ID), 0);
+    }
+
+    function testReclaimMultipleRegisteredNameCloseToExpiryShouldExtend(
+        address[4] calldata users,
+        address mod,
+        address recovery,
+        address[4] calldata destinations
+    ) public {
+        _assumeClean(mod);
+        _assumeClean(recovery);
+        address[] memory addresses = new address[](10);
+        for (uint256 i = 0; i < users.length; i++) {
+            _assumeClean(users[i]);
+            _assumeClean(destinations[i]);
+            addresses[i] = users[i];
+            addresses[i + 4] = destinations[i];
+        }
+        addresses[8] = mod;
+        addresses[9] = recovery;
+        _assumeUnique(addresses);
+
+        bytes16[] memory fnames = new bytes16[](4);
+        fnames[0] = "alice";
+        fnames[1] = "bob";
+        fnames[2] = "carol";
+        fnames[3] = "dan";
+
+        uint256[] memory tokenIds = new uint256[](4);
+        tokenIds[0] = ALICE_TOKEN_ID;
+        tokenIds[1] = BOB_TOKEN_ID;
+        tokenIds[2] = CAROL_TOKEN_ID;
+        tokenIds[3] = DAN_TOKEN_ID;
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _register(users[i], fnames[i]);
+        }
+
+        uint256 renewalTs = block.timestamp + REGISTRATION_PERIOD;
+        _grant(MODERATOR_ROLE, mod);
+
+        for (uint256 i = 0; i < fnames.length; i++) {
+            _requestRecovery(users[i], tokenIds[i], recovery);
+        }
+
+        // Fast forward to just before the renewals expire
+        vm.warp(renewalTs - 1);
+        NameRegistry.ReclaimAction[] memory reclaimActions = new NameRegistry.ReclaimAction[](4);
+
+        for (uint256 i = 0; i < users.length; i++) {
+            reclaimActions[i] = NameRegistry.ReclaimAction(tokenIds[i], destinations[i]);
+            vm.expectEmit(true, true, true, true);
+            emit Transfer(users[i], destinations[i], tokenIds[i]);
+        }
+        vm.prank(mod);
+        nameRegistry.reclaim(reclaimActions);
+
+        // reclaim should extend the expiry ahead of the current timestamp
+        uint256 expectedExpiryTs = block.timestamp + RENEWAL_PERIOD;
+
+        for (uint256 i = 0; i < users.length; i++) {
+            assertEq(nameRegistry.balanceOf(users[i]), 0);
+            assertEq(nameRegistry.balanceOf(destinations[i]), 1);
+            assertEq(nameRegistry.expiryOf(tokenIds[i]), expectedExpiryTs);
+            assertEq(nameRegistry.ownerOf(tokenIds[i]), destinations[i]);
+            assertEq(nameRegistry.recoveryOf(tokenIds[i]), address(0));
+            assertEq(nameRegistry.recoveryClockOf(tokenIds[i]), 0);
+        }
     }
 
     function testReclaimExpiredNames(address alice, address mod, address recovery) public {


### PR DESCRIPTION
## Motivation

This pull request is to add another method that allows reclaiming multiple usernames to multiple destinations. It tackles some of the issue discussed [here](https://github.com/farcasterxyz/contracts/issues/153) 

## Change Summary

The changes in this PR:

 - defines `reclaimAction` struct which consists of a `tokenId` (corresponding to a username) & `destination` (destination addresses to reclaim the username to)
 - defines a new `reclaim` function that accepts an array of `reclaimAction` structs to reclaim multiple usernames to different destination addresses.
 - defines a few test cases for the new `reclaim`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.
