### PR TITLE
docs(fname): regex to match protocol

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -57,7 +57,7 @@ The fid state can automatically transition when certain periods of time pass:
 
 The Name Registry contract issues Farcaster names (fnames) for the Farcaster network.
 
-An `fname` is an ERC-721 token that represents a unique name like @alice. An fname can have up to 16 characters that include lowercase letters, numbers or hyphens. It should that match the regular expression `^[a-zA-Z0-9-]{1,16}$`. The address that owns an fname is known as the `custody address`. The contract implements a [recovery system](#3-recovery-system) that protects users if they lose access to this address. Similar to IDs, Farcaster Names also begin in the invitable state, where they can only be registered by a pre-determined address. The owner can disable trusted registration which then allows anyone to register an fname.
+An `fname` is an ERC-721 token that represents a unique name like @alice. An fname can have up to 16 characters that include lowercase letters, numbers or hyphens. It should that match the regular expression `/^[a-z0-9][a-z0-9-]{0,15}$/`. The address that owns an fname is known as the `custody address`. The contract implements a [recovery system](#3-recovery-system) that protects users if they lose access to this address. Similar to IDs, Farcaster Names also begin in the invitable state, where they can only be registered by a pre-determined address. The owner can disable trusted registration which then allows anyone to register an fname.
 
 Fnames can be registered for one year by paying the registration fee, similar to domain names. Unlike most ERC-721 tokens, minting the token does not imply permanent ownership. Registration uses a two-phase commit reveal system to prevent frontrunning.
 


### PR DESCRIPTION
match protocol [spec](https://github.com/farcasterxyz/protocol/blob/main/README.md#22-farcaster-names)

Contract also [implements](https://github.com/farcasterxyz/contracts/blob/767c94165f9b4ec3a08698fb842468bb2bd79347/src/NameRegistry.sol#L1075) the protocol fname regex forbidding hyphens in the first character

## Motivation

Inconsistencies in the docs are confusing for newcomers,

## Change Summary

Fix out-dated contract docs to match protocol docs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

This is a simple fix to the docs.
