### PR TITLE
ci: call forge-fmt directly instead of using yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,6 @@ jobs:
           cache: "yarn"
           node-version: "18"
 
-      - name: Restore cached dependencies for Node modules
-        id: module-cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Run audit
-        run: yarn audit
-
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -51,8 +38,8 @@ jobs:
           forge --version
           forge build --sizes
 
-      - name: Run forge formatter
-        run: yarn format:check
+      - name: Run forge fmt
+        run: forge fmt --check
 
       - name: Run forge tests
         run: forge test -vvv

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "lint-staged": "^13.0.2"
   },
   "scripts": {
-    "prepare": "husky install",
-    "format": "forge fmt",
-    "format:check": "forge fmt --check",
-    "solhint": "solhint --config \"./.solhint.json\" \"{src,test}/**/*.sol\""
-  }
+    "prepare": "husky install"
+ }
 }


### PR DESCRIPTION
## Motivation
 
Speeds up tests by avoiding usage of yarn 

## Change Summary

- Called forge fmt directly in CI
- Removed setup and restore of yarn packages in CI
- Removed unused yarn command

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
