### PR TITLE
ci: use simple actions instead of codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,30 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Check code coverage
-        run: |
-          forge coverage --report lcov
-        id: coverage
+        run: forge coverage --report summary --report lcov
 
-      - uses: codecov/codecov-action@v3
+      # Ignores coverage results for the test and script directories. Note that because this
+      # filtering applies to the lcov file, the summary table generated in the previous step will
+      # still include all files and directories.
+      # The `--rc lcov_branch_coverage=1` part keeps branch info in the filtered report, since lcov
+      # defaults to removing branch info.
+      - name: Filter directories
+        run: |
+          sudo apt update && sudo apt install -y lcov
+          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1
+
+      # Post a detailed coverage report as a comment and deletes previous comments on each push.
+      - name: Post coverage report
+        if: github.event_name == 'pull_request' # This action fails when ran outside of a pull request.
+        uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          delete-old-comments: true
+          lcov-file: ./lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
+
+      # Fail coverage if the specified coverage threshold is not met
+      - name: Verify minimum coverage
+        uses: zgosalvez/github-actions-report-lcov@v2
+        with:
+          coverage-files: ./lcov.info
+          minimum-coverage: 94


### PR DESCRIPTION
## Motivation

Codecov bot is sometimes slow or unresponsive and coverage results aren't available at merge time

## Change Summary

Use simpler actions from ScopeLift's security template that write results directly to PR. 

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)