### PR TITLE
perf(NameRegistry): reduce gas usage in reclaim with unchecked math

### DIFF
--- a/src/NameRegistry.sol
+++ b/src/NameRegistry.sol
@@ -989,12 +989,19 @@ contract NameRegistry is
             /* Transfer the name with super.ownerOf so that it works even if the name is expired */
             _transfer(super.ownerOf(tokenId), reclaimActions[i].destination, tokenId);
 
-            /* If the fname expires soon, extend its expiry by 30 days */
-            if (block.timestamp >= _expiry - RENEWAL_PERIOD) {
-                metadataOf[tokenId].expiryTs = uint40(block.timestamp + RENEWAL_PERIOD);
-            }
+            /**
+             * If the fname expires soon, extend its expiry by 30 days
+             *
+             * Safety: RENEWAL_PERIOD is a constant much smaller than _expiry which is a recent
+             * block.timestamp and subtraction cannot underflow.
+             *
+             * Safety: block.timestamp + RENEWAL_PERIOD cannot overflow a uint40 for many years.
+             */
 
             unchecked {
+                if (block.timestamp >= _expiry - RENEWAL_PERIOD) {
+                    metadataOf[tokenId].expiryTs = uint40(block.timestamp + RENEWAL_PERIOD);
+                }
                 i++; // Safety: the loop ends if i is >= reclaimActions.length
             }
         }

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -1494,11 +1494,11 @@ contract NameRegistryTest is Test {
 
         _requestRecovery(alice, recovery);
 
-        // alice sets charlie as her approver
+        // alice sets her approver
         vm.prank(alice);
         nameRegistry.approve(approver, ALICE_TOKEN_ID);
 
-        // alice transfers @alice to bob
+        // approver transfers @alice to bob
         vm.prank(approver);
         vm.expectEmit(true, true, true, true);
         emit Transfer(alice, bob, ALICE_TOKEN_ID);


### PR DESCRIPTION
## Motivation

Avoid checked math for statements that cannot underflow or overflow given constraints

## Change Summary

Removed checks in reclaim() which reduces gas usage by ~300 for batch reclaims of 4

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
