### PR TITLE
test: fix fuzzer failures where one address collidied with exisiting contracts

### DIFF
--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -213,6 +213,7 @@ contract NameRegistryTest is Test {
     ) public {
         vm.assume(bob != address(0));
         _assumeClean(alice);
+        _assumeClean(bob);
         _disableTrusted();
         vm.warp(JAN1_2023_TS);
 

--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -244,24 +244,24 @@ contract NameRegistryTest is Test {
         address alice,
         address recovery,
         bytes32 secret,
-        uint256 delay_bob,
-        uint256 delay_alice
+        uint256 delayBob,
+        uint256 delayAlice
     ) public {
         _assumeClean(alice);
         _disableTrusted();
         vm.deal(alice, 1 ether);
         vm.warp(JAN1_2023_TS);
 
-        delay_alice = delay_alice % FUZZ_TIME_PERIOD;
-        delay_bob = delay_bob % FUZZ_TIME_PERIOD;
-        vm.assume(delay_alice >= COMMIT_REPLAY_DELAY);
-        vm.assume(delay_bob >= COMMIT_REPLAY_DELAY);
+        delayAlice = delayAlice % FUZZ_TIME_PERIOD;
+        delayBob = delayBob % FUZZ_TIME_PERIOD;
+        vm.assume(delayAlice >= COMMIT_REPLAY_DELAY);
+        vm.assume(delayBob >= COMMIT_REPLAY_DELAY);
 
         // Register @alice to alice
         vm.startPrank(alice);
         bytes32 commitHashAlice = nameRegistry.generateCommit("alice", alice, secret, recovery);
         nameRegistry.makeCommit(commitHashAlice);
-        vm.warp(block.timestamp + delay_alice);
+        vm.warp(block.timestamp + delayAlice);
         uint256 aliceRegister = block.timestamp;
         nameRegistry.register{value: nameRegistry.fee()}("alice", alice, secret, recovery);
 
@@ -271,7 +271,7 @@ contract NameRegistryTest is Test {
         // Register @bob to alice
         bytes32 commitHashBob = nameRegistry.generateCommit("bob", alice, secret, recovery);
         nameRegistry.makeCommit(commitHashBob);
-        vm.warp(block.timestamp + delay_bob);
+        vm.warp(block.timestamp + delayBob);
         uint256 bobRegister = block.timestamp;
         nameRegistry.register{value: FEE}("bob", alice, secret, recovery);
         vm.stopPrank();


### PR DESCRIPTION
## Motivation

Fix false positive error in fuzzing.

## Change Summary

Remove pre existing contracts in our foundry environment from the fuzzer inputs for transfer targets

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)