### PR TITLE
test: add coverage to BundleRegistry.register for overpayment

### DIFF
--- a/test/BundleRegistry/BundleRegistry.t.sol
+++ b/test/BundleRegistry/BundleRegistry.t.sol
@@ -203,7 +203,7 @@ contract BundleRegistryTest is BundleRegistryTestSuite {
 
         // call register() from address(this) which is non-payable
         // overpay by 1 wei to return funds which causes the revert
-        vm.expectRevert(NameRegistry.CallFailed.selector);
+        vm.expectRevert(BundleRegistry.CallFailed.selector);
         bundleRegistry.register{value: FEE + 1 wei}(alice, recovery, "alice", secret);
 
         _assertUnsuccessfulRegistration(alice);

--- a/test/BundleRegistry/BundleRegistry.t.sol
+++ b/test/BundleRegistry/BundleRegistry.t.sol
@@ -207,7 +207,6 @@ contract BundleRegistryTest is BundleRegistryTestSuite {
         bundleRegistry.register{value: FEE + 1 wei}(alice, recovery, "alice", secret);
 
         _assertUnsuccessfulRegistration(alice);
-
         assertEq(nameRegistry.timestampOf(commitHash), commitTs);
     }
 


### PR DESCRIPTION
## Motivation

This PR address issue https://github.com/farcasterxyz/contracts/issues/204 and adds 1 new test testing BundleRegistry.register behaviour in the case of an overpayment.

## Change Summary

I think we have tested some overpayment behaviour by checking the balances of relayer & bundleRegistry [here](https://github.com/farcasterxyz/contracts/blob/0696f82ebc9e2605c5dc7b00e75d2339a620c6bc/test/BundleRegistry.t.sol#L119). What I assume we haven't tested is the behaviour of overpayment in the case of non-payable address as we have tested for NameRegistry [here](https://github.com/farcasterxyz/contracts/blob/0696f82ebc9e2605c5dc7b00e75d2339a620c6bc/test/NameRegistry.t.sol#L646). For which I add `testFuzzCannotRegisterFromNonPayableIfOverpaying`.

Please do let me know if this is what you mean by "coverage to BundleRegistry.register for overpayment".

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/proto
