### PR TITLE
test(NameRegistry): unicode string inputs for fnames

### DIFF
--- a/test/NameRegistry.t.sol
+++ b/test/NameRegistry.t.sol
@@ -93,6 +93,9 @@ contract NameRegistryTest is Test {
 
     function testFuzzCannotGenerateCommitWithInvalidName(address alice, bytes32 secret, address recovery) public {
         vm.expectRevert(NameRegistry.InvalidName.selector);
+        nameRegistry.generateCommit("-", alice, secret, recovery);
+
+        vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit("Alice", alice, secret, recovery);
 
         vm.expectRevert(NameRegistry.InvalidName.selector);
@@ -113,21 +116,33 @@ contract NameRegistryTest is Test {
         vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit(" alice", alice, secret, recovery);
 
+        vm.expectRevert(NameRegistry.InvalidName.selector);
+        nameRegistry.generateCommit(unicode"￾", alice, secret, recovery);
+
+        vm.expectRevert(NameRegistry.InvalidName.selector);
+        nameRegistry.generateCommit(unicode"��", alice, secret, recovery);
+
+        vm.expectRevert(NameRegistry.InvalidName.selector);
+        nameRegistry.generateCommit(unicode"﷽", alice, secret, recovery);
+
+        vm.expectRevert(NameRegistry.InvalidName.selector);
+        nameRegistry.generateCommit(unicode"😃", alice, secret, recovery);
+
         bytes16 blankName = 0x00000000000000000000000000000000;
         vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit(blankName, alice, secret, recovery);
 
-        // Should reject "a�ice", where � == 129 which is an invalid ASCII character
+        // Reject "a�ice", where � == 129 which is an invalid ASCII character
         bytes16 nameWithInvalidAsciiChar = 0x61816963650000000000000000000000;
         vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit(nameWithInvalidAsciiChar, alice, secret, recovery);
 
-        // Should reject "a�ice", where � == NULL
+        // Reject "a�ice", where � == NULL
         bytes16 nameWithEmptyByte = 0x61006963650000000000000000000000;
         vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit(nameWithEmptyByte, alice, secret, recovery);
 
-        // Should reject "�lice", where � == NULL
+        // Reject "�lice", where � == NULL
         bytes16 nameWithStartingEmptyByte = 0x006c6963650000000000000000000000;
         vm.expectRevert(NameRegistry.InvalidName.selector);
         nameRegistry.generateCommit(nameWithStartingEmptyByte, alice, secret, recovery);


### PR DESCRIPTION
## Motivation

Add additional test coverage for unicode strings, which should all fail the validateFname function

## Change Summary

Added tests for  ￾, ��,  ﷽ and😃

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
