### PR TITLE
test: add test register after transfer

### DIFF
--- a/test/IdRegistry.t.sol
+++ b/test/IdRegistry.t.sol
@@ -242,6 +242,25 @@ contract IdRegistryTest is Test {
         assertEq(idRegistry.idOf(bob), 0);
     }
 
+    function testFuzzTransferReregister(address alice, address bob) public {
+        vm.assume(alice != FORWARDER && alice != bob);
+        _register(alice);
+
+        assertEq(idRegistry.idOf(alice), 1);
+        assertEq(idRegistry.idOf(bob), 0);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, bob, 1);
+        idRegistry.transfer(bob);
+
+        assertEq(idRegistry.idOf(alice), 0);
+        assertEq(idRegistry.idOf(bob), 1);
+
+        _register(alice);
+        assertEq(idRegistry.idOf(alice), 2);
+    }
+
     /*//////////////////////////////////////////////////////////////
                           CHANGE RECOVERY TESTS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
## Motivation

This PR address issue https://github.com/farcasterxyz/contracts/issues/210 and adds 1 new test.

## Change Summary

Adds `testFuzzTransferReregister` which test that an address that owns an fid can successfully transfer out the fid and register a new one .

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.
