### PR TITLE
fix: reorder expectEmit

### DIFF
--- a/test/IdRegistry/IdRegistry.owner.t.sol
+++ b/test/IdRegistry/IdRegistry.owner.t.sol
@@ -51,8 +51,8 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.getTrustedOnly(), 1);
 
         vm.expectEmit(true, true, true, true);
-        idRegistry.disableTrustedOnly();
         emit DisableTrustedOnly();
+        idRegistry.disableTrustedOnly();
         assertEq(idRegistry.getTrustedOnly(), 0);
     }
 


### PR DESCRIPTION
## Motivation

Foundry 1.0 made a [breaking change](https://github.com/foundry-rs/foundry/blob/master/CHANGELOG.md#breaking-changes) to the behavior of `vm.expectEmit` so that it only applies to the next call. This means tests are now more sensitive to the order in which the expectation, `emit`, and call are defined. Looks like there's one test in the FC contracts that's affected.

## Change Summary

Reorder call in `IdRegistryOwnertest#FuzzDisableTrustedCaller`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

An alternative fix is to pin the latest stable pre-1.0 Foundry in CI following the instructions [here](https://github.com/foundry-rs/foundry/blob/master/CHANGELOG.md#breaking-changes) rather than keep up with Foundry nightly.
