### PR TITLE
chore: increase optimizer runs to 100k

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc_version = "0.8.18"
-optimizer_runs = 10_000
+optimizer_runs = 100_000
 fuzz = { runs = 512 }
 remappings = [
   "solmate/=lib/solmate/",


### PR DESCRIPTION
## Motivation

Optimizer runs should typically be set to the number of times you expect the contract to be called. When the NameRegistry contract was included, this had to be set lower than expected since it made the contract too large to deploy. With the removal of the NameRegistry, this is now safe to add back. 

Note that this change does not have any impact on the gas efficiency of the IdRegistry, which is already maximally optimized, but may impact future contracts. 

## Change Summary

- Changed `optimizer_runs` from 10k to 100k

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the optimizer runs in the `foundry.toml` file and adds a remapping.

### Detailed summary
- `optimizer_runs` increased from 10,000 to 100,000 in `foundry.toml`
- Added a remapping for `solmate/` to `lib/solmate/` in `foundry.toml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->