### PR TITLE
feat(IdRegistry): instant recovery

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 936789)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931617)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 1783048)
-IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 797254)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 936789)
+IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -16,7 +16,7 @@ import {ERC2771Context} from "openzeppelin-contracts/contracts/metatx/ERC2771Con
  *         The IdRegistry starts in the seedable state where only a trusted caller can register
  *         fids and later moves to an open state where any address can register an fid. The
  *         Registry implements a recovery system which lets the address that owns an fid nominate
- *         a recovery address that can transfer the fid to a new address after a delay.
+ *         a recovery address that can transfer the fid to a new address.
  */
 contract IdRegistry is ERC2771Context, Ownable {
     /*//////////////////////////////////////////////////////////////
@@ -93,7 +93,7 @@ contract IdRegistry is ERC2771Context, Ownable {
     uint256 internal idCounter;
 
     /**
-     * @dev The Farcaster Invite service address that is allowed to call trustedRegister.
+     * @dev The admin address that is allowed to call trustedRegister.
      */
     address internal trustedCaller;
 
@@ -249,8 +249,8 @@ contract IdRegistry is ERC2771Context, Ownable {
      */
 
     /**
-     * @notice Change the recovery address of the fid owned by the caller and reset active recovery
-     *         requests. Supports ERC 2771 meta-transactions and can be called by a relayer.
+     * @notice Change the recovery address of the fid owned by the caller. Supports ERC 2771
+     *         meta-transactions and can be called by a relayer.
      *
      * @param recovery The address which can recover the fid (set to 0x0 to disable recovery).
      */

--- a/test/IdRegistry/IdRegistry.gas.t.sol
+++ b/test/IdRegistry/IdRegistry.gas.t.sol
@@ -22,23 +22,9 @@ contract IdRegistryGasUsageTest is IdRegistryTestSuite {
             idRegistry.register(alice, RECOVERY);
             assertEq(idRegistry.idOf(address(uint160(i))), i + 1);
 
-            // Requesting a recovery should be done multiple times to get a good median value,
-            // since it adds new storage slots.
-            for (uint256 j = 0; j < 5; j++) {
-                vm.prank(RECOVERY);
-                idRegistry.requestRecovery(alice, RECOVERY);
-            }
-
-            // Cancelling and the recovery can be done once per user since it adds no new storage
-            vm.prank(alice);
-            idRegistry.cancelRecovery(alice);
-
-            vm.prank(RECOVERY);
-            idRegistry.requestRecovery(alice, address(uint160(i + 100)));
-
             vm.warp(block.timestamp + 7 days);
             vm.prank(RECOVERY);
-            idRegistry.completeRecovery(alice);
+            idRegistry.recover(alice, address(uint160(i + 100)));
         }
     }
 

--- a/test/IdRegistry/IdRegistry.gas.t.sol
+++ b/test/IdRegistry/IdRegistry.gas.t.sol
@@ -17,12 +17,10 @@ contract IdRegistryGasUsageTest is IdRegistryTestSuite {
         // initializes storage and has extra costs
 
         for (uint256 i = 0; i < 15; i++) {
-            // Register the name
             address alice = address(uint160(i));
             idRegistry.register(alice, RECOVERY);
             assertEq(idRegistry.idOf(address(uint160(i))), i + 1);
 
-            vm.warp(block.timestamp + 7 days);
             vm.prank(RECOVERY);
             idRegistry.recover(alice, address(uint160(i + 100)));
         }

--- a/test/IdRegistry/IdRegistryTestSuite.sol
+++ b/test/IdRegistry/IdRegistryTestSuite.sol
@@ -35,9 +35,4 @@ abstract contract IdRegistryTestSuite is Test {
         vm.prank(caller);
         idRegistry.register(caller, recovery);
     }
-
-    function _assertNoRecoveryState(uint256 fid) internal {
-        assertEq(idRegistry.getRecoveryTsOf(fid), 0);
-        assertEq(idRegistry.getRecoveryDestinationOf(fid), address(0));
-    }
 }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -19,14 +19,6 @@ contract IdRegistryHarness is IdRegistry {
         return recoveryOf[id];
     }
 
-    function getRecoveryTsOf(uint256 id) public view returns (uint256) {
-        return uint256(recoveryStateOf[id].startTs);
-    }
-
-    function getRecoveryDestinationOf(uint256 id) public view returns (address) {
-        return recoveryStateOf[id].destination;
-    }
-
     function getTrustedCaller() public view returns (address) {
         return trustedCaller;
     }


### PR DESCRIPTION
## Motivation

See [FIP: Instant Recovery](https://github.com/farcasterxyz/protocol/discussions/100)

## Change Summary

Changes the recovery system to be instantaneous

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a recovery feature to the IdRegistry contract and updates related tests. 

### Detailed summary
- Adds a `recover()` function to transfer ownership of an Id to a new address.
- Removes the `requestRecovery()` and `completeRecovery()` functions.
- Removes the `RecoveryState` struct and related mapping.
- Updates the `changeRecoveryAddress()` function to only change the recovery address.
- Updates related tests and removes unnecessary ones.

> The following files were skipped due to too many changes: `test/IdRegistry/IdRegistry.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->