### PR TITLE
docs(IdRegistry): update docs to match instant recovery changes

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -13,7 +13,7 @@ The ID Registry contract issues Farcaster IDs (fids) for the Farcaster network.
 
 An `fid` is a uint256 that represents a unique user of the network. Fids begin at 0 and increment by one for every new account. There is an infinite supply of fids since they can go as high as ~10^77. IDs begin in the seedable state, where they can only be registered by a pre-determined address. The owner can disable trusted registration which then allows anyone to register an fid.
 
-Each address can only own a single fid at a time, but they can otherwise be freely transferred between addresses. The address that currently owns an fid is known as the `custody address`. The contract implements a recovery system that protects users if they lose access to this address.
+Each address can only own a single fid at a time, but they can otherwise be freely transferred between addresses. The address that currently owns an fid is known as the `custody address`. The `custody address` can nominate a `recovery address` that is authorized to move a fid on its behalf. This can be changed or removed at any time.
 
 ### State Machine
 
@@ -22,8 +22,6 @@ An fid can exist in these states:
 - `seedable` - the fid has never been issued, and can be registered by the trusted caller
 - `registerable` - the fid has never been issued, and can be registered by anyone
 - `registered` - the fid has been issued to an address
-- `escrow` - a recovery request has been submitted and is pending escrow
-- `recoverable` - a recovery request has completed escrow and is pending completion.
 
 ```mermaid
     stateDiagram-v2
@@ -31,11 +29,7 @@ An fid can exist in these states:
         seedable --> registerable: disable trusted register
         seedable --> registered: trusted register
         registerable --> registered: register
-        registered --> registered: transfer
-        registered --> escrow: request recovery
-        escrow --> recoverable: end(escrow)
-        recoverable --> registered: transfer, cancel <br>  or complete recovery
-        escrow --> registered: transfer <br> cancel recovery
+        registered --> registered: transfer, recover
 ```
 
 The fid state transitions when users take specific actions:
@@ -44,26 +38,8 @@ The fid state transitions when users take specific actions:
 - `trusted register` - register a new fid from the trusted caller
 - `disable trusted register` - allow registration from any sender
 - `transfer` - move an fid to a new custody address
-- `request recovery` - request a recovery of the fid
-- `cancel recovery` - cancel a recovery that is in progress
-- `complete recovery` - complete a recovery that has passed the escrow period
+- `recover` - recover (move) an fid to a new custody address
 
-The fid state can automatically transition when certain periods of time pass:
-
-- `end(escrow)` - 3 days from the `request recovery` action
-
-
-### Recovery System
-
-The contract implement a recovery system that protects the owner against the loss of the `custody address`.
-
-1. The `custody address` can nominate a `recovery address` that is authorized to move a fid on its behalf. This can be changed or removed at any time.
-
-2. The `recovery address` can send a recovery request which moves the fid into the `escrow` state. After the escrow period, the fid becomes `recoverable`, and the `recovery address` can complete the transfer.
-
-3. During `escrow`, the `custody address` can cancel the recovery, which protects against malicious recovery addresses.
-
-4. The `recovery address` is removed, and any active requests are cancelled if the `custody address` changes due to a transfer or other action.
 
 # 2. Storage Contract
 


### PR DESCRIPTION
## Motivation

Update docs to match changes in https://github.com/farcasterxyz/contracts/pull/226

## Change Summary

Update docs to match changes in https://github.com/farcasterxyz/contracts/pull/226

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the fid contract, specifically adding information on the recovery system and updating the state machine diagram.

### Detailed summary
- Adds information on the recovery system for the contract
- Updates the state machine diagram to reflect changes in fid state transitions
- Clarifies that custody addresses can nominate recovery addresses to move fids on their behalf
- Removes mentions of the `escrow` and `recoverable` states from the state machine diagram and transitions, as they are no longer used in the contract

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->