### PR TITLE
feat(IdRegistry): don't reset recovery address on transfer

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931617)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 928173)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "forge fmt && forge test -vvv && forge snapshot --check --match-contract Gas"
+pre-commit = "forge fmt && forge snapshot --check --match-contract Gas && forge test -vvv"
 
 [logging]
 verbose = true

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -226,9 +226,6 @@ contract IdRegistry is ERC2771Context, Ownable {
         idOf[to] = id;
         delete idOf[from];
 
-        /* Effect: clear the recovery address */
-        delete recoveryOf[id];
-
         emit Transfer(from, to, id);
     }
 

--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -164,7 +164,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.idOf(bob), 1);
     }
 
-    function testFuzzTransferResetsRecoveryState(
+    function testFuzzTransferDoesntResetRecoveryState(
         address alice,
         address bob,
         address recovery,
@@ -184,7 +184,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
 
         assertEq(idRegistry.idOf(alice), 0);
         assertEq(idRegistry.idOf(bob), 1);
-        assertEq(idRegistry.getRecoveryOf(1), address(0));
+        assertEq(idRegistry.getRecoveryOf(1), recovery);
     }
 
     function testFuzzCannotTransferToAddressWithId(address alice, address bob, address recovery) public {
@@ -278,7 +278,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
 
         assertEq(idRegistry.idOf(from), 0);
         assertEq(idRegistry.idOf(to), 1);
-        assertEq(idRegistry.getRecoveryOf(1), address(0));
+        assertEq(idRegistry.getRecoveryOf(1), recovery);
     }
 
     function testFuzzCannotRecoverWithoutId(address from, address recovery, address to) public {


### PR DESCRIPTION
## Motivation

Users who perform a recovery or transfer will automatically lose their recovery address, which leads to more lost accounts. Not resetting the recovery address is a better experience that protects users. 

## Change Summary

Recovery address is no longer reset when `transfer` or `recover` is called successfully

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
