### PR TITLE
chore(IdRegistry): allow registrations to be paused by admin

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,7 @@
+<<<<<<< HEAD
 IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 928101)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)
+=======
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931168)
+IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 800729)
+>>>>>>> 034fb45 (chore(IdRegistry): allow registrations to be paused by admin)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,7 +1,2 @@
-<<<<<<< HEAD
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 928101)
-IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)
-=======
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931168)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931096)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 800729)
->>>>>>> 034fb45 (chore(IdRegistry): allow registrations to be paused by admin)

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.19;
 
 import {Context} from "openzeppelin/contracts/utils/Context.sol";
 import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "openzeppelin/contracts/security/Pausable.sol";
+
 import {ERC2771Context} from "openzeppelin-contracts/contracts/metatx/ERC2771Context.sol";
 
 /**
@@ -18,7 +20,7 @@ import {ERC2771Context} from "openzeppelin-contracts/contracts/metatx/ERC2771Con
  *         Registry implements a recovery system which lets the address that owns an fid nominate
  *         a recovery address that can transfer the fid to a new address.
  */
-contract IdRegistry is ERC2771Context, Ownable {
+contract IdRegistry is ERC2771Context, Ownable, Pausable {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -168,7 +170,6 @@ contract IdRegistry is ERC2771Context, Ownable {
         if (msg.sender != trustedCaller) revert Unauthorized();
 
         _unsafeRegister(to, recovery);
-
         emit Register(to, idCounter, recovery);
     }
 
@@ -176,7 +177,7 @@ contract IdRegistry is ERC2771Context, Ownable {
      * @dev Registers a new, unique fid and sets up a recovery address for a caller without
      *      checking all invariants or emitting events.
      */
-    function _unsafeRegister(address to, address recovery) internal {
+    function _unsafeRegister(address to, address recovery) internal whenNotPaused {
         /* Revert if the destination(to) already has an fid */
         if (idOf[to] != 0) revert HasId();
 
@@ -322,6 +323,20 @@ contract IdRegistry is ERC2771Context, Ownable {
 
         /* Clear pending owner so that this cannot be called again without a new request */
         delete pendingOwner;
+    }
+
+    /**
+     * @notice Pause all registrations. Must be called by the owner.
+     */
+    function pauseRegistration() public onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @notice Unpause all registrations. Must be called by the owner.
+     */
+    function unpauseRegistration() public onlyOwner {
+        _unpause();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -136,7 +136,7 @@ contract IdRegistry is ERC2771Context, Ownable, Pausable {
      *                   verify the authenticity of signed meta-transaction requests.
      */
     // solhint-disable-next-line no-empty-blocks
-    constructor(address _forwarder) ERC2771Context(_forwarder) Ownable() {}
+    constructor(address _forwarder) ERC2771Context(_forwarder) Ownable() Pausable() {}
 
     /*//////////////////////////////////////////////////////////////
                              REGISTRATION LOGIC
@@ -328,14 +328,14 @@ contract IdRegistry is ERC2771Context, Ownable, Pausable {
     /**
      * @notice Pause all registrations. Must be called by the owner.
      */
-    function pauseRegistration() public onlyOwner {
+    function pauseRegistration() external onlyOwner {
         _pause();
     }
 
     /**
      * @notice Unpause all registrations. Must be called by the owner.
      */
-    function unpauseRegistration() public onlyOwner {
+    function unpauseRegistration() external onlyOwner {
         _unpause();
     }
 

--- a/test/IdRegistry/IdRegistry.owner.t.sol
+++ b/test/IdRegistry/IdRegistry.owner.t.sol
@@ -160,4 +160,44 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.owner(), owner);
         assertEq(idRegistry.getPendingOwner(), newOwner);
     }
+
+    function testPauseRegistration() public {
+        assertEq(idRegistry.owner(), owner);
+        assertEq(idRegistry.paused(), false);
+
+        _pauseRegistrations();
+    }
+
+    function testFuzzCannotPauseRegistrationUnlessOwner(address alice) public {
+        vm.assume(alice != FORWARDER && alice != owner && alice != address(0));
+        assertEq(idRegistry.owner(), owner);
+        assertEq(idRegistry.paused(), false);
+
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        idRegistry.pauseRegistration();
+
+        assertEq(idRegistry.paused(), false);
+    }
+
+    function testUnpauseRegistration() public {
+        _pauseRegistrations();
+
+        vm.prank(owner);
+        idRegistry.unpauseRegistration();
+
+        assertEq(idRegistry.paused(), false);
+    }
+
+    function testFuzzCannotUnpauseUnlessOwner(address alice) public {
+        vm.assume(alice != FORWARDER && alice != owner && alice != address(0));
+        assertEq(idRegistry.owner(), owner);
+        _pauseRegistrations();
+
+        vm.prank(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        idRegistry.unpauseRegistration();
+
+        assertEq(idRegistry.paused(), true);
+    }
 }

--- a/test/IdRegistry/IdRegistryTestSuite.sol
+++ b/test/IdRegistry/IdRegistryTestSuite.sol
@@ -35,4 +35,10 @@ abstract contract IdRegistryTestSuite is Test {
         vm.prank(caller);
         idRegistry.register(caller, recovery);
     }
+
+    function _pauseRegistrations() public {
+        vm.prank(owner);
+        idRegistry.pauseRegistration();
+        assertEq(idRegistry.paused(), true);
+    }
 }


### PR DESCRIPTION
## Motivation

Pause can be used to stop registration temporarily or permanently which will be useful if we ever need to redeploy the contract or migrate to another chain.

## Change Summary

OpenZeppelin's Pausable is used grant the owner permissions to pause and unpause the contract. When paused, registrations will be prevented but all other operations may continue. 

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding the ability to pause and unpause registrations in the `IdRegistry` contract.

### Detailed summary:
- Added a new function `_pauseRegistrations()` to pause registrations.
- Added a new function `testPauseRegistration()` to test the pausing functionality.
- Added a new function `testFuzzCannotPauseRegistrationUnlessOwner()` to test that only the owner can pause registrations.
- Added a new function `testUnpauseRegistration()` to test the unpausing functionality.
- Added a new function `testFuzzCannotUnpauseUnlessOwner()` to test that only the owner can unpause registrations.
- Added the `Pausable` import to the `IdRegistry.sol` file.
- Modified the `IdRegistry` contract to inherit from `Pausable`.
- Added the `pauseRegistration()` function to pause registrations.
- Added the `unpauseRegistration()` function to unpause registrations.
- Added the `testFuzzCannotRegisterIfPaused()` function to test that registrations cannot be done when the registrations are paused.
- Added the `testFuzzCannotTrustedRegisterWhenPaused()` function to test that trusted registrations cannot be done when the registrations are paused.
- Added the `testFuzzTransferWhenPaused()` function to test that transfers cannot be done when the registrations are paused.
- Added the `testFuzzChangeRecoveryAddressWhenPaused()` function to test that changing the recovery address cannot be done when the registrations are paused.
- Added the `testFuzzRecoverWhenPaused()` function to test that recoveries cannot be done when the registrations are paused.
- Added the necessary assumptions and assertions for the new tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->