### PR TITLE
docs: update documentation and rename some methods for clarity

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 928173)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 928101)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 795536)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # Contracts
 
-Implementation of the Farcaster Contracts as specified in the
-[Farcaster protocol](https://github.com/farcasterxyz/protocol). Learn more about how the contracts work by reading the
-[docs](docs/docs.md) or [contributing guidelines](CONTRIBUTING.md).
+This repository contains all the contracts deployed by the [Farcaster protocol](https://github.com/farcasterxyz/protocol). The contracts are: 
+
+1. **Registry** - issues identities to new users.
+2. **Storage** - allocates storage to users and collects rent.
+3. **Bundler** - allows calling registry and storage in a single transaction. 
+4. **Farcaster CCIP** - validates Farcaster ENS names which were issued off-chain. 
+
+Read the [docs](docs/docs.md) for more details on how the contracts work. 
+
+
+## Contributing
+
+Please see the [contributing guidelines](CONTRIBUTING.md).
 
 ## Location
 
 ### v3 Contracts
 
-The v3 contracts in this repository have not yet been deployed. 
+The v3 contracts have not yet been deployed. 
 
 ### v2 Contracts
 
-The v2 contracts from an older version of this repository can be found at the following addresses on Goerli
+The [v2 contracts](https://github.com/farcasterxyz/contracts/releases/tag/v2.0.0) can be found at the following addresses on L1 Goerli:
 
 | Network        | Address                                                                                                                      |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,23 +1,25 @@
 # Farcaster Contracts Documentation
 
-Documentation that covers the high-level functionality of each contract in the system.
-
 ## Table of Contents
 
-1. [ID Registry](#1-id-registry)
-2. [Storage Contract](#2-storage-contract)
+1. [Registry](#1-registry)
+2. [Storage Contract](#2-storage)
+3. [Bundler Contract](#3-bundler)
+4. [ENS CCIP Contract](#4-ccip)
 
-## 1. ID Registry
+## 1. Registry
 
-The ID Registry contract issues Farcaster IDs (fids) for the Farcaster network.
+The Registry contract lets users sign up and claim and identity on the Farcaster network. Users can call the contract to get identifier known as a Farcaster ID or `fid`. This is a unique integer which is mapped to the user's address known as the `custody address`. The Registry starts in the Seedable state where only a `trusted caller` can register new fids. This is used to migrate state safely if the contract ever needs to be redeployed.
 
-An `fid` is a uint256 that represents a unique user of the network. Fids begin at 0 and increment by one for every new account. There is an infinite supply of fids since they can go as high as ~10^77. IDs begin in the seedable state, where they can only be registered by a pre-determined address. The owner can disable trusted registration which then allows anyone to register an fid.
+A custody address can only own one fid at a time. Fids can be freely transferred between addresses as long as they do not violate this rule. The custody address can optionally nominate a `recovery address` that can authorized to move the fid at anytime. The custody address can change or remove the recovery address at any time.
 
-Each address can only own a single fid at a time, but they can otherwise be freely transferred between addresses. The address that currently owns an fid is known as the `custody address`. The `custody address` can nominate a `recovery address` that is authorized to move a fid on its behalf. This can be changed or removed at any time.
+### Administration
+
+An `owner` address can change the contract state to Registrable, where anyone can register fids. This state change cannot be undone. The owner can also pause and unpause registrations though transfers and recoveries are not affected. 
 
 ### State Machine
 
-An fid can exist in these states:
+An fid can exist in three states:
 
 - `seedable` - the fid has never been issued, and can be registered by the trusted caller
 - `registerable` - the fid has never been issued, and can be registered by anyone
@@ -26,7 +28,7 @@ An fid can exist in these states:
 ```mermaid
     stateDiagram-v2
         direction LR
-        seedable --> registerable: disable trusted register
+        seedable --> registerable: disable trusted only
         seedable --> registered: trusted register
         registerable --> registered: register
         registered --> registered: transfer, recover
@@ -36,11 +38,35 @@ The fid state transitions when users take specific actions:
 
 - `register` - register a new fid from any address
 - `trusted register` - register a new fid from the trusted caller
-- `disable trusted register` - allow registration from any sender
+- `disable trusted only` - allow registration from any sender
 - `transfer` - move an fid to a new custody address
 - `recover` - recover (move) an fid to a new custody address
 
 
-# 2. Storage Contract
+# 2. Storage
 
-TBD
+The Storage contract lets users with an fid rent storage space on Farcaster Hubs. Users must make a payment in Ethereum to the contract to acquire units of storage for one year. Acquiring storage emits an event which is read off-chian by the Farcaster Hubs, which allocate the appropriate space to the user. There is a maximum number of storage units available for rent defined as tunable parameter. 
+
+The contract is programmed to deprecate itself at a certain date, initialized to 1 year after the deployment. We expect to launch a new contract to handle rent every year with updated logic based on market conditions, though may extend the lifetime of the contract if necessary.
+
+### Pricing
+
+The rent price of a unit of storage is denominated in USD but must be paid in ETH. A chainlink price oracle is used to determine the exchange rate. Prices are updated periodically by calling the price feed, though guardrails are in place to ensure that prices are not updated if they are stale, out of bounds or if the sequencer was recently restarted. 
+
+Price changes occur when a transaction is made after the cache period has passed. The next payment of rent automatically invokes the price refresh. If the price is refreshed in a block, all transactions in that block are still allowed to pay the old price, and the refreshed price is only applied to future blocks, to make payments more predictable. 
+ 
+### Administration
+
+An `operator` address can credit storage to fids without the payment of rent. This is used for the initial migration to assign storage to existing users, so that their messages aren't auto-expired from Hubs.
+
+A `treasurer` address can move funds out of the contract to a pre-defined `vault` address, but cannot change this destination. Only the `admin` may change the address of the vault to a new destination. 
+
+An `admin` address can modify many parameters including the total supply of storage units, the price of rent, the duration for which exchange prices are valid and the deprecation timestamp. 
+
+# 3. Bundler
+
+In Progress
+
+# 4. CCIP
+
+In Progress

--- a/test/IdRegistry/IdRegistry.metatx.t.sol
+++ b/test/IdRegistry/IdRegistry.metatx.t.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.19;
 
 import {MinimalForwarder} from "openzeppelin/contracts/metatx/MinimalForwarder.sol";
 
-import {IdRegistryHarness} from "./Utils.sol";
+import {IdRegistryHarness} from "../Utils.sol";
 
-import {TestSuiteSetup} from "./TestSuiteSetup.sol";
+import {TestSuiteSetup} from "../TestSuiteSetup.sol";
 
 /* solhint-disable state-visibility */
 /* solhint-disable avoid-low-level-calls */
 
-contract MetaTxTest is TestSuiteSetup {
+contract IdRegistryMetaTxTest is TestSuiteSetup {
     IdRegistryHarness idRegistry;
     MinimalForwarder forwarder;
 
@@ -89,8 +89,8 @@ contract MetaTxTest is TestSuiteSetup {
             abi.encode(_TYPEHASH_FW_REQ, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data))
         );
 
-        // Pack the prefix, domain separator and hashStruct into a bytestring, hash it, sign it, and pack the
-        // signature into a single value
+        // Pack the prefix, domain separator and hashStruct into a bytestring, hash it, sign it,
+        // and pack the signature into a single value
         bytes32 message = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), hashStruct));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, message);
         return abi.encodePacked(r, s, v);

--- a/test/IdRegistry/IdRegistry.owner.t.sol
+++ b/test/IdRegistry/IdRegistry.owner.t.sol
@@ -17,6 +17,10 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
     event DisableTrustedOnly();
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    /*//////////////////////////////////////////////////////////////
+                             TRUSTED CALLER
+    //////////////////////////////////////////////////////////////*/
+
     function testFuzzChangeTrustedCaller(address alice) public {
         vm.assume(alice != FORWARDER && alice != address(0));
         assertEq(idRegistry.owner(), owner);
@@ -66,7 +70,11 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.getTrustedOnly(), 1);
     }
 
-    function testFuzzCannotTransferOwnershipWithoutRequestFlow(address newOwner) public {
+    /*//////////////////////////////////////////////////////////////
+                           TRANSFER OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzzCannotTransferOwnership(address newOwner) public {
         assertEq(idRegistry.owner(), owner);
         assertEq(idRegistry.getPendingOwner(), address(0));
 
@@ -76,6 +84,10 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.owner(), owner);
         assertEq(idRegistry.getPendingOwner(), address(0));
     }
+
+    /*//////////////////////////////////////////////////////////////
+                       REQUEST TRANSFER OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
 
     function testFuzzRequestTransferOwnership(address newOwner, address newOwner2) public {
         vm.assume(newOwner != address(0) && newOwner2 != address(0));
@@ -115,6 +127,10 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.owner(), owner);
         assertEq(idRegistry.getPendingOwner(), address(0));
     }
+
+    /*//////////////////////////////////////////////////////////////
+                       COMPLETE TRANSFER OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
 
     function testFuzzCompleteTransferOwnership(address newOwner) public {
         vm.assume(newOwner != FORWARDER && newOwner != owner && newOwner != address(0));


### PR DESCRIPTION
## Motivation

Makes the codebase easier to understand

## Change Summary

- Updated README and docs
- Updated file, function and variable names related to IdRegistry
- Updated inline documentation

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
This PR focuses on the IdRegistry and Storage contracts. Notable changes include:
- Renaming of `MetaTxTest` to `IdRegistryMetaTxTest`
- File path changes for imports in `IdRegistryMetaTxTest`
- Updates to the `README.md` file
- Updates to the `docs/docs.md` file
- Changes to the `IdRegistryOwnerTest` contract
- Updates to the `StorageRentTest` contract

> The following files were skipped due to too many changes: `test/StorageRent/StorageRent.t.sol`, `src/IdRegistry.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->