### PR TITLE
feat: add FnameResolver

### DIFF
--- a/script/helpers/IdRegistryFab.sol
+++ b/script/helpers/IdRegistryFab.sol
@@ -13,7 +13,7 @@ contract IdRegistryFab {
 
     constructor(address trustedForwarder, address initialOwner, bytes32 salt) {
         IdRegistry registry = new IdRegistry{ salt: salt }(trustedForwarder);
-        registry.requestTransferOwnership(initialOwner);
+        registry.transferOwnership(initialOwner);
         registryAddr = address(registry);
     }
 }

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
+import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+bytes32 constant USERNAME_PROOF_TYPEHASH = keccak256("UsernameProof(string name,uint256 timestamp,address owner)");
+
+struct UsernameProof {
+    string name;
+    uint256 timestamp;
+    address owner;
+}
+
+contract FnameResolver is EIP712, Ownable2Step {
+    error OffchainLookup(address sender, string[] urls, bytes callData, bytes4 callbackFunction, bytes extraData);
+    error InvalidSignature();
+
+    event AddSigner(address indexed signer);
+    event RemoveSigner(address indexed signer);
+
+    string public url;
+
+    mapping(address signer => bool isAuthorized) public signers;
+
+    constructor(string memory _url, address _signer) EIP712("Farcaster name verification", "1") {
+        url = _url;
+        signers[_signer] = true;
+        emit AddSigner(_signer);
+    }
+
+    function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory) {
+        bytes memory callData = abi.encodeCall(this.resolve, (name, data));
+        string[] memory urls = new string[](1);
+        urls[0] = url;
+        revert OffchainLookup(address(this), urls, callData, this.resolveWithProof.selector, callData);
+    }
+
+    function resolveWithProof(
+        bytes calldata response,
+        bytes calldata /* extraData */
+    ) external view returns (bytes memory) {
+        (bytes memory result, UsernameProof memory proof, bytes memory signature) =
+            abi.decode(response, (bytes, UsernameProof, bytes));
+        bytes32 eip712hash =
+            _hashTypedDataV4(keccak256(abi.encode(USERNAME_PROOF_TYPEHASH, proof.name, proof.timestamp, proof.owner)));
+        address signer = ECDSA.recover(eip712hash, signature);
+        if (!signers[signer]) revert InvalidSignature();
+        return result;
+    }
+
+    function addSigner(address signer) external onlyOwner {
+        signers[signer] = true;
+        emit AddSigner(signer);
+    }
+
+    function removeSigner(address signer) external onlyOwner {
+        signers[signer] = false;
+        emit RemoveSigner(signer);
+    }
+}

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -5,14 +5,6 @@ import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
 import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
-bytes32 constant USERNAME_PROOF_TYPEHASH = keccak256("UsernameProof(string name,uint256 timestamp,address owner)");
-
-struct UsernameProof {
-    string name;
-    uint256 timestamp;
-    address owner;
-}
-
 contract FnameResolver is EIP712, Ownable2Step {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
@@ -64,6 +56,20 @@ contract FnameResolver is EIP712, Ownable2Step {
      */
     bytes32 internal constant _USERNAME_PROOF_TYPEHASH =
         keccak256("UsernameProof(string name,uint256 timestamp,address owner)");
+
+    /*//////////////////////////////////////////////////////////////
+                                STRUCTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice An FIP-90 username proof.
+     *         See: https://github.com/farcasterxyz/protocol/discussions/90
+     */
+    struct UsernameProof {
+        string name;
+        uint256 timestamp;
+        address owner;
+    }
 
     /*//////////////////////////////////////////////////////////////
                               PARAMETERS
@@ -119,7 +125,7 @@ contract FnameResolver is EIP712, Ownable2Step {
         (bytes memory result, UsernameProof memory proof, bytes memory signature) =
             abi.decode(response, (bytes, UsernameProof, bytes));
         bytes32 eip712hash =
-            _hashTypedDataV4(keccak256(abi.encode(USERNAME_PROOF_TYPEHASH, proof.name, proof.timestamp, proof.owner)));
+            _hashTypedDataV4(keccak256(abi.encode(_USERNAME_PROOF_TYPEHASH, proof.name, proof.timestamp, proof.owner)));
         address signer = ECDSA.recover(eip712hash, signature);
         if (!signers[signer]) revert InvalidSigner();
         return result;

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -14,22 +14,94 @@ struct UsernameProof {
 }
 
 contract FnameResolver is EIP712, Ownable2Step {
-    error OffchainLookup(address sender, string[] urls, bytes callData, bytes4 callbackFunction, bytes extraData);
-    error InvalidSignature();
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
 
+    /**
+     * @dev Revert to indicate an offchain CCIP lookup. See: https://eips.ethereum.org/EIPS/eip-3668
+     *
+     * @param sender           Address of this contract.
+     * @param urls             List of lookup gateway URLs.
+     * @param callData         Data to call the gateway with.
+     * @param callbackFunction 4 byte function selector of the callback function on this contract.
+     * @param extraData        Additional data required by the callback function.
+     */
+    error OffchainLookup(address sender, string[] urls, bytes callData, bytes4 callbackFunction, bytes extraData);
+
+    /// @dev Revert if the recovered signer address is not an authorized signer.
+    error InvalidSigner();
+
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Emit an event when the contract owner authorizes a new signer.
+     *
+     * @param signer Address of the authorized signer.
+     */
     event AddSigner(address indexed signer);
+
+    /**
+     * @dev Emit an event when the contract owner removes an authorized signer.
+     *
+     * @param signer Address of the removed signer.
+     */
     event RemoveSigner(address indexed signer);
 
+    /*//////////////////////////////////////////////////////////////
+                                CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Contract version. Follows Farcaster protocol version scheme.
+     */
+    string public constant VERSION = "2023.07.12";
+
+    /**
+     * @dev EIP-712 typehash of the UsernameProof struct.
+     */
+    bytes32 internal constant _USERNAME_PROOF_TYPEHASH =
+        keccak256("UsernameProof(string name,uint256 timestamp,address owner)");
+
+    /*//////////////////////////////////////////////////////////////
+                              PARAMETERS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev URL of the CCIP lookup gateway.
+     */
     string public url;
 
+    /**
+     * @dev Mapping of signer address to authorized boolean.
+     */
     mapping(address signer => bool isAuthorized) public signers;
 
+    /*//////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Set the lookup gateway URL, and initial signer.
+     *
+     * @param _url                     Lookup gateway URL. This value is set permanently.
+     * @param _signer                  Initial authorized signer address.
+     */
     constructor(string memory _url, address _signer) EIP712("Farcaster name verification", "1") {
         url = _url;
         signers[_signer] = true;
         emit AddSigner(_signer);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                             RESOLVER VIEWS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Resolve the provided ENS name. This function will always revert to indicate an offchain lookup.
+     */
     function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory) {
         bytes memory callData = abi.encodeCall(this.resolve, (name, data));
         string[] memory urls = new string[](1);
@@ -37,6 +109,9 @@ contract FnameResolver is EIP712, Ownable2Step {
         revert OffchainLookup(address(this), urls, callData, this.resolveWithProof.selector, callData);
     }
 
+    /**
+     * @notice Offchain lookup callback. The caller must provide the signed response returned by the lookup gateway.
+     */
     function resolveWithProof(
         bytes calldata response,
         bytes calldata /* extraData */
@@ -46,15 +121,29 @@ contract FnameResolver is EIP712, Ownable2Step {
         bytes32 eip712hash =
             _hashTypedDataV4(keccak256(abi.encode(USERNAME_PROOF_TYPEHASH, proof.name, proof.timestamp, proof.owner)));
         address signer = ECDSA.recover(eip712hash, signature);
-        if (!signers[signer]) revert InvalidSignature();
+        if (!signers[signer]) revert InvalidSigner();
         return result;
     }
 
+    /*//////////////////////////////////////////////////////////////
+                         PERMISSIONED ACTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Add a signer address to the authorized mapping. Only callable by owner.
+     *
+     * @param signer The signer address.
+     */
     function addSigner(address signer) external onlyOwner {
         signers[signer] = true;
         emit AddSigner(signer);
     }
 
+    /**
+     * @notice Remove a signer address from the authorized mapping. Only callable by owner.
+     *
+     * @param signer The signer address.
+     */
     function removeSigner(address signer) external onlyOwner {
         signers[signer] = false;
         emit RemoveSigner(signer);

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+
+import "../TestConstants.sol";
+import {FnameResolverTestSuite} from "./FnameResolverTestSuite.sol";
+import {FnameResolver, UsernameProof, USERNAME_PROOF_TYPEHASH} from "../../src/FnameResolver.sol";
+
+/* solhint-disable state-visibility */
+
+contract FnameResolverTest is FnameResolverTestSuite {
+    event AddSigner(address indexed signer);
+    event RemoveSigner(address indexed signer);
+
+    function testURL() public {
+        assertEq(resolver.url(), FNAME_SERVER_URL);
+    }
+
+    function testSignerIsAuthorized() public {
+        assertEq(resolver.signers(signer), true);
+    }
+
+    function testFuzzResolveRevertsWithOffchainLookup(bytes calldata name, bytes calldata data) public {
+        string[] memory urls = new string[](1);
+        urls[0] = FNAME_SERVER_URL;
+
+        bytes memory callData = abi.encodeCall(resolver.resolve, (name, data));
+
+        bytes memory offchainLookup = abi.encodeWithSelector(
+            FnameResolver.OffchainLookup.selector,
+            address(resolver),
+            urls,
+            callData,
+            resolver.resolveWithProof.selector,
+            callData
+        );
+        vm.expectRevert(offchainLookup);
+        resolver.resolve(name, data);
+    }
+
+    function testFuzzResolveWithProofValidSignature(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result
+    ) public {
+        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+        bytes memory signature = _signProof(name, timestamp, owner);
+
+        bytes memory response = resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+        assertEq(response, result);
+    }
+
+    function testFuzzResolveWithProofInvalidOwner(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result
+    ) public {
+        address wrongOwner = address(~uint160(owner));
+        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: wrongOwner});
+        bytes memory signature = _signProof(name, timestamp, owner);
+
+        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+    }
+
+    function testFuzzResolveWithProofInvalidTimestamp(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result
+    ) public {
+        uint256 wrongTimestamp = ~timestamp;
+        UsernameProof memory proof = UsernameProof({name: name, timestamp: wrongTimestamp, owner: owner});
+        bytes memory signature = _signProof(name, timestamp, owner);
+
+        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+    }
+
+    function testFuzzResolveWithProofInvalidName(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result
+    ) public {
+        string memory wrongName = string.concat("~", name);
+        UsernameProof memory proof = UsernameProof({name: wrongName, timestamp: timestamp, owner: owner});
+        bytes memory signature = _signProof(name, timestamp, owner);
+
+        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+    }
+
+    function testFuzzResolveWithProofWrongSigner(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result
+    ) public {
+        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+        bytes memory signature = _signProof(malloryPk, name, timestamp, owner);
+
+        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+    }
+
+    function testFuzzResolveWithProofInvalidSignatureLength(
+        string memory name,
+        uint256 timestamp,
+        address owner,
+        bytes calldata result,
+        bytes memory signature,
+        uint8 _length
+    ) public {
+        vm.assume(signature.length >= 65);
+        uint256 length = bound(_length, 0, 64);
+        assembly {
+            mstore(signature, length)
+        } /* truncate signature length */
+        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+
+        vm.expectRevert("ECDSA: invalid signature length");
+        resolver.resolveWithProof(abi.encode(result, proof, signature), "");
+    }
+
+    function testFuzzOwnerCanAddSigner(address signer) public {
+        vm.expectEmit(true, false, false, false);
+        emit AddSigner(signer);
+
+        vm.prank(owner);
+        resolver.addSigner(signer);
+
+        assertEq(resolver.signers(signer), true);
+    }
+
+    function testFuzzOnlyOwnerCanAddSigner(address caller, address signer) public {
+        vm.assume(caller != owner);
+
+        vm.prank(caller);
+        vm.expectRevert("Ownable: caller is not the owner");
+        resolver.addSigner(signer);
+    }
+
+    function testFuzzOwnerCanRemoveSigner(address signer) public {
+        vm.prank(owner);
+        resolver.addSigner(signer);
+
+        assertEq(resolver.signers(signer), true);
+
+        vm.expectEmit(true, false, false, false);
+        emit RemoveSigner(signer);
+
+        vm.prank(owner);
+        resolver.removeSigner(signer);
+
+        assertEq(resolver.signers(signer), false);
+    }
+
+    function testFuzzOnlyOwnerCanRemoveSigner(address caller, address signer) public {
+        vm.assume(caller != owner);
+
+        vm.prank(caller);
+        vm.expectRevert("Ownable: caller is not the owner");
+        resolver.removeSigner(signer);
+    }
+
+    function _signProof(
+        string memory name,
+        uint256 timestamp,
+        address owner
+    ) internal returns (bytes memory signature) {
+        return _signProof(signerPk, name, timestamp, owner);
+    }
+
+    function _signProof(
+        uint256 pk,
+        string memory name,
+        uint256 timestamp,
+        address owner
+    ) internal returns (bytes memory signature) {
+        bytes32 eip712hash =
+            resolver.hashTypedDataV4(keccak256(abi.encode(USERNAME_PROOF_TYPEHASH, name, timestamp, owner)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, eip712hash);
+        signature = abi.encodePacked(r, s, v);
+        assertEq(signature.length, 65);
+    }
+}

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -6,7 +6,7 @@ import {IERC165} from "openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import "../TestConstants.sol";
 import {FnameResolverTestSuite} from "./FnameResolverTestSuite.sol";
-import {FnameResolver, IResolverService, IExtendedResolver} from "../../src/FnameResolver.sol";
+import {FnameResolver, IResolverService, IExtendedResolver, IAddressQuery} from "../../src/FnameResolver.sol";
 
 /* solhint-disable state-visibility */
 
@@ -22,7 +22,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         assertEq(resolver.signers(signer), true);
     }
 
-    function testFuzzResolveRevertsWithOffchainLookup(bytes calldata name, bytes calldata data) public {
+    function testFuzzResolveRevertsWithOffchainLookup(bytes calldata name, bytes memory data) public {
+        data = bytes.concat(IAddressQuery.addr.selector, data);
         string[] memory urls = new string[](1);
         urls[0] = FNAME_SERVER_URL;
 
@@ -41,7 +42,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
 
     function testFuzzResolveWithProofValidSignature(string memory name, uint256 timestamp, address owner) public {
         bytes memory signature = _signProof(name, timestamp, owner);
-        bytes memory extraData = abi.encodeCall(IResolverService.resolve, (DNS_ENCODED_NAME, ADDR_FUNCTION_CALL));
+        bytes memory extraData = abi.encodeCall(IResolverService.resolve, (DNS_ENCODED_NAME, ADDR_QUERY_CALLDATA));
         bytes memory response = resolver.resolveWithProof(abi.encode(name, timestamp, owner, signature), extraData);
         assertEq(response, abi.encode(owner));
     }

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -62,7 +62,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
         UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: wrongOwner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
-        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        vm.expectRevert(FnameResolver.InvalidSigner.selector);
         resolver.resolveWithProof(abi.encode(result, proof, signature), "");
     }
 
@@ -76,7 +76,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
         UsernameProof memory proof = UsernameProof({name: name, timestamp: wrongTimestamp, owner: owner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
-        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        vm.expectRevert(FnameResolver.InvalidSigner.selector);
         resolver.resolveWithProof(abi.encode(result, proof, signature), "");
     }
 
@@ -90,7 +90,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
         UsernameProof memory proof = UsernameProof({name: wrongName, timestamp: timestamp, owner: owner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
-        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        vm.expectRevert(FnameResolver.InvalidSigner.selector);
         resolver.resolveWithProof(abi.encode(result, proof, signature), "");
     }
 
@@ -103,11 +103,11 @@ contract FnameResolverTest is FnameResolverTestSuite {
         UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
         bytes memory signature = _signProof(malloryPk, name, timestamp, owner);
 
-        vm.expectRevert(FnameResolver.InvalidSignature.selector);
+        vm.expectRevert(FnameResolver.InvalidSigner.selector);
         resolver.resolveWithProof(abi.encode(result, proof, signature), "");
     }
 
-    function testFuzzResolveWithProofInvalidSignatureLength(
+    function testFuzzResolveWithProofInvalidSignerLength(
         string memory name,
         uint256 timestamp,
         address owner,

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
+import {IERC165} from "openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import "../TestConstants.sol";
 import {FnameResolverTestSuite} from "./FnameResolverTestSuite.sol";
-import {FnameResolver} from "../../src/FnameResolver.sol";
+import {FnameResolver, IExtendedResolver} from "../../src/FnameResolver.sol";
 
 /* solhint-disable state-visibility */
 
@@ -171,6 +172,19 @@ contract FnameResolverTest is FnameResolverTestSuite {
         vm.prank(caller);
         vm.expectRevert("Ownable: caller is not the owner");
         resolver.removeSigner(signer);
+    }
+
+    function testInterfaceDetectionIExtendedResolver() public {
+        assertEq(resolver.supportsInterface(type(IExtendedResolver).interfaceId), true);
+    }
+
+    function testInterfaceDetectionERC165() public {
+        assertEq(resolver.supportsInterface(type(IERC165).interfaceId), true);
+    }
+
+    function testFuzzInterfaceDetectionUnsupportedInterface(bytes4 interfaceId) public {
+        vm.assume(interfaceId != type(IExtendedResolver).interfaceId && interfaceId != type(IERC165).interfaceId);
+        assertEq(resolver.supportsInterface(interfaceId), false);
     }
 
     function _signProof(

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import "../TestConstants.sol";
 import {FnameResolverTestSuite} from "./FnameResolverTestSuite.sol";
-import {FnameResolver, UsernameProof, USERNAME_PROOF_TYPEHASH} from "../../src/FnameResolver.sol";
+import {FnameResolver} from "../../src/FnameResolver.sol";
 
 /* solhint-disable state-visibility */
 
@@ -45,7 +45,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         address owner,
         bytes calldata result
     ) public {
-        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: name, timestamp: timestamp, owner: owner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
         bytes memory response = resolver.resolveWithProof(abi.encode(result, proof, signature), "");
@@ -59,7 +60,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         bytes calldata result
     ) public {
         address wrongOwner = address(~uint160(owner));
-        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: wrongOwner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: name, timestamp: timestamp, owner: wrongOwner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
         vm.expectRevert(FnameResolver.InvalidSigner.selector);
@@ -73,7 +75,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         bytes calldata result
     ) public {
         uint256 wrongTimestamp = ~timestamp;
-        UsernameProof memory proof = UsernameProof({name: name, timestamp: wrongTimestamp, owner: owner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: name, timestamp: wrongTimestamp, owner: owner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
         vm.expectRevert(FnameResolver.InvalidSigner.selector);
@@ -87,7 +90,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         bytes calldata result
     ) public {
         string memory wrongName = string.concat("~", name);
-        UsernameProof memory proof = UsernameProof({name: wrongName, timestamp: timestamp, owner: owner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: wrongName, timestamp: timestamp, owner: owner});
         bytes memory signature = _signProof(name, timestamp, owner);
 
         vm.expectRevert(FnameResolver.InvalidSigner.selector);
@@ -100,7 +104,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         address owner,
         bytes calldata result
     ) public {
-        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: name, timestamp: timestamp, owner: owner});
         bytes memory signature = _signProof(malloryPk, name, timestamp, owner);
 
         vm.expectRevert(FnameResolver.InvalidSigner.selector);
@@ -120,7 +125,8 @@ contract FnameResolverTest is FnameResolverTestSuite {
         assembly {
             mstore(signature, length)
         } /* truncate signature length */
-        UsernameProof memory proof = UsernameProof({name: name, timestamp: timestamp, owner: owner});
+        FnameResolver.UsernameProof memory proof =
+            FnameResolver.UsernameProof({name: name, timestamp: timestamp, owner: owner});
 
         vm.expectRevert("ECDSA: invalid signature length");
         resolver.resolveWithProof(abi.encode(result, proof, signature), "");
@@ -182,7 +188,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
         address owner
     ) internal returns (bytes memory signature) {
         bytes32 eip712hash =
-            resolver.hashTypedDataV4(keccak256(abi.encode(USERNAME_PROOF_TYPEHASH, name, timestamp, owner)));
+            resolver.hashTypedDataV4(keccak256(abi.encode(resolver.usernameProofTypehash(), name, timestamp, owner)));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, eip712hash);
         signature = abi.encodePacked(r, s, v);
         assertEq(signature.length, 65);

--- a/test/FnameResolver/FnameResolverTestSuite.sol
+++ b/test/FnameResolver/FnameResolverTestSuite.sol
@@ -11,7 +11,27 @@ import {FnameResolverHarness} from "../Utils.sol";
 abstract contract FnameResolverTestSuite is Test {
     FnameResolverHarness internal resolver;
 
-    string internal constant FNAME_SERVER_URL = "https://fnames.farcaster.xyz/";
+    string internal constant FNAME_SERVER_URL = "https://fnames.farcaster.xyz/ccip/{sender}/{data}.json";
+
+    /**
+     * @dev DNS-encoding of "alice.farcaster.xyz". The DNS-encoded name consists of:
+     *      - 1 byte for the length of the first label (5)
+     *      - 5 bytes for the label ("alice")
+     *      - 1 byte for the length of the second label (9)
+     *      - 9 bytes for the label ("farcaster")
+     *      - 1 byte for the length of the third label (3)
+     *      - 3 bytes for the label ("xyz")
+     *      - A null byte terminating the encoded name.
+     */
+    bytes internal constant DNS_ENCODED_NAME =
+        (hex"05" hex"616c696365" hex"09" hex"666172636173746572" hex"03" hex"78797a" hex"00");
+
+    /**
+     * @dev Encoded calldata for a call to addr(bytes32 node), where node is the ENS
+     *      nameHash encoded value of "alice.farcaster.xyz"
+     */
+    bytes internal constant ADDR_FUNCTION_CALL =
+        hex"3b3b57de00d4f449060ad2a07ff5ad355ae8da52281e95f6ad10fb923ae7cad9f2c43c2a";
 
     address internal signer;
     uint256 internal signerPk;

--- a/test/FnameResolver/FnameResolverTestSuite.sol
+++ b/test/FnameResolver/FnameResolverTestSuite.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+import {FnameResolverHarness} from "../Utils.sol";
+
+/* solhint-disable state-visibility */
+
+abstract contract FnameResolverTestSuite is Test {
+    FnameResolverHarness internal resolver;
+
+    string internal constant FNAME_SERVER_URL = "https://fnames.farcaster.xyz/";
+
+    address internal signer;
+    uint256 internal signerPk;
+
+    address internal mallory;
+    uint256 internal malloryPk;
+
+    address internal owner = address(this);
+
+    function setUp() public {
+        (signer, signerPk) = makeAddrAndKey("signer");
+        (mallory, malloryPk) = makeAddrAndKey("mallory");
+        resolver = new FnameResolverHarness(FNAME_SERVER_URL, signer);
+    }
+}

--- a/test/FnameResolver/FnameResolverTestSuite.sol
+++ b/test/FnameResolver/FnameResolverTestSuite.sol
@@ -30,7 +30,7 @@ abstract contract FnameResolverTestSuite is Test {
      * @dev Encoded calldata for a call to addr(bytes32 node), where node is the ENS
      *      nameHash encoded value of "alice.farcaster.xyz"
      */
-    bytes internal constant ADDR_FUNCTION_CALL =
+    bytes internal constant ADDR_QUERY_CALLDATA =
         hex"3b3b57de00d4f449060ad2a07ff5ad355ae8da52281e95f6ad10fb923ae7cad9f2c43c2a";
 
     address internal signer;

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -24,6 +24,10 @@ contract FnameResolverHarness is FnameResolver {
     function hashTypedDataV4(bytes32 structHash) public view returns (bytes32) {
         return _hashTypedDataV4(structHash);
     }
+
+    function usernameProofTypehash() public view returns (bytes32) {
+        return _USERNAME_PROOF_TYPEHASH;
+    }
 }
 
 /**

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -25,7 +25,7 @@ contract FnameResolverHarness is FnameResolver {
         return _hashTypedDataV4(structHash);
     }
 
-    function usernameProofTypehash() public view returns (bytes32) {
+    function usernameProofTypehash() public pure returns (bytes32) {
         return _USERNAME_PROOF_TYPEHASH;
     }
 }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import {AggregatorV3Interface} from "chainlink/v0.8/interfaces/AggregatorV3Interface.sol";
 
+import {FnameResolver} from "../src/FnameResolver.sol";
 import {IdRegistry} from "../src/IdRegistry.sol";
 import {StorageRent} from "../src/StorageRent.sol";
 import {Bundler} from "../src/Bundler.sol";
@@ -15,6 +16,14 @@ contract BundlerHarness is Bundler {
         address _storageRent,
         address _trustedCaller
     ) Bundler(_idRegistry, _storageRent, _trustedCaller) {}
+}
+
+contract FnameResolverHarness is FnameResolver {
+    constructor(string memory _url, address _signer) FnameResolver(_url, _signer) {}
+
+    function hashTypedDataV4(bytes32 structHash) public view returns (bytes32) {
+        return _hashTypedDataV4(structHash);
+    }
 }
 
 /**


### PR DESCRIPTION
## Motivation

Add `FnameResolver` offchain resolver contract. See https://github.com/farcasterxyz/protocol/discussions/90 for spec and discussion.

## Change Summary

Add a new `FnameResolver` CCIP resolver contract, based on the ENS example [here](https://github.com/ensdomains/offchain-resolver).

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus:
This PR focuses on making changes to the `IdRegistryFab.sol` and `FnameResolver.sol` contracts, as well as adding test cases and a test suite for the `FnameResolver` contract.

### Detailed summary:
- In `IdRegistryFab.sol`:
  - The `requestTransferOwnership` function is replaced with `transferOwnership`.
- In `test/Utils.sol`:
  - The `FnameResolver` contract is imported.
  - The `IdRegistry`, `StorageRent`, and `Bundler` contracts are imported.
- In `test/FnameResolver/FnameResolverTestSuite.sol`:
  - The `FnameResolverHarness` contract is added.
- In `test/FnameResolver/FnameResolverTestSuite.sol`:
  - The `FnameResolverHarness` contract is added.
  - The `setUp` function is added.
- In `test/FnameResolver/FnameResolver.t.sol`:
  - The `FnameResolverTest` contract is added.
  - Various test functions are added.
- In `src/FnameResolver.sol`:
  - The `FnameResolver` contract is added.
  - The `OffchainLookup`, `ResolverFunctionNotSupported`, and `InvalidSigner` errors are added.
  - The `AddSigner` and `RemoveSigner` events are added.
  - The `VERSION` constant is added.
  - The `_USERNAME_PROOF_TYPEHASH` constant is added.

> The following files were skipped due to too many changes: `src/FnameResolver.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->