### PR TITLE
feat(IdRegistry): use Ownable2Step instead of custom Ownable

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 931096)
-IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 800729)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 932696)
+IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 801586)

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -29,10 +29,6 @@ contract IdRegistryHarness is IdRegistry {
     function getTrustedOnly() public view returns (uint256) {
         return trustedOnly;
     }
-
-    function getPendingOwner() public view returns (address) {
-        return pendingOwner;
-    }
 }
 
 contract StorageRentHarness is StorageRent {


### PR DESCRIPTION
## Motivation

Using Ownable2Step instead of our custom extension on Ownable will be safer since its codepaths have more eyes on them. 

## Change Summary

- Idregistry now inherits Ownable2Step instead of Ownable
- Removed all custom overrides and methods that made Ownable work in a two phase mode

Gas usage for `register` increased by 54, `idOf` by 22

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)



<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to make changes to the `IdRegistry` contract.
- Notable changes include:
  - Importing the `Ownable2Step` contract instead of `Ownable`.
  - Removing the `Pausable` contract from the inheritance list.
  - Removing the `pendingOwner` variable and related functions.
  - Adding a new `acceptOwnership` function.
  - Updating the `testFuzzTransferOwnership` and `testFuzzAcceptOwnership` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->