### PR TITLE
chore: upgrade openzeppelin-contracts from 4.8.1 to 4.9.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 	branch = v1
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/openzeppelin/openzeppelin-contracts
-	branch = v4.8.1
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
@@ -13,3 +9,6 @@
 [submodule "lib/chainlink-brownie-contracts"]
 	path = lib/chainlink-brownie-contracts
 	url = https://github.com/smartcontractkit/chainlink-brownie-contracts
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,6 @@ fuzz = { runs = 512 }
 remappings = [
   "solmate/=lib/solmate/",
   "openzeppelin/=lib/openzeppelin-contracts/",
-  "openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
   "chainlink/=lib/chainlink-brownie-contracts/contracts/src/"
 ]
 


### PR DESCRIPTION
## Motivation

Upgrade to the latest version of openzeppelin-contracts. Changelog [here](https://github.com/OpenZeppelin/openzeppelin-contracts/releases).

## Change Summary

Upgrade to the latest version of openzeppelin-contracts. 

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the submodule URL for `lib/openzeppelin-contracts`. 

### Detailed summary
- Updated submodule URL for `lib/openzeppelin-contracts` to https://github.com/openzeppelin/openzeppelin-contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->