### PR TITLE
fix: register and exclude known contract addresses

### DIFF
--- a/test/StorageRent/StorageRent.t.sol
+++ b/test/StorageRent/StorageRent.t.sol
@@ -128,6 +128,8 @@ contract StorageRentTest is StorageRentTestSuite {
         int256 newEthUsdPrice,
         uint256 warp
     ) public {
+        _assumeClean(msgSender1);
+        _assumeClean(msgSender2);
         uint256 lastPriceFeedUpdateTime = storageRent.lastPriceFeedUpdateTime();
         uint256 lastPriceFeedUpdateBlock = storageRent.lastPriceFeedUpdateBlock();
         uint256 ethUsdPrice = storageRent.ethUsdPrice();
@@ -161,6 +163,8 @@ contract StorageRentTest is StorageRentTestSuite {
         uint200 units2,
         int256 newEthUsdPrice
     ) public {
+        _assumeClean(msgSender1);
+        _assumeClean(msgSender2);
         uint256 ethUsdPrice = storageRent.ethUsdPrice();
 
         // Ensure Chainlink price is positive
@@ -193,6 +197,8 @@ contract StorageRentTest is StorageRentTestSuite {
         uint200 units2,
         uint256 decrease
     ) public {
+        _assumeClean(msgSender1);
+        _assumeClean(msgSender2);
         uint256 ethUsdPrice = storageRent.ethUsdPrice();
 
         decrease = bound(decrease, 1, ethUsdPrice);
@@ -225,6 +231,8 @@ contract StorageRentTest is StorageRentTestSuite {
         uint200 units2,
         uint256 increase
     ) public {
+        _assumeClean(msgSender1);
+        _assumeClean(msgSender2);
         uint256 ethUsdPrice = storageRent.ethUsdPrice();
 
         increase = bound(increase, 1, uint256(type(int256).max) - ethUsdPrice);

--- a/test/StorageRent/StorageRentTestSuite.sol
+++ b/test/StorageRent/StorageRentTestSuite.sol
@@ -78,5 +78,10 @@ abstract contract StorageRentTestSuite is TestSuiteSetup {
             operator,
             treasurer
         );
+
+        addKnownContract(address(priceFeed));
+        addKnownContract(address(uptimeFeed));
+        addKnownContract(address(revertOnReceive));
+        addKnownContract(address(storageRent));
     }
 }

--- a/test/TestSuiteSetup.sol
+++ b/test/TestSuiteSetup.sol
@@ -46,6 +46,10 @@ abstract contract TestSuiteSetup is Test {
                                  HELPERS
     //////////////////////////////////////////////////////////////*/
 
+    function addKnownContract(address contractAddress) public {
+        isKnownContract[contractAddress] = true;
+    }
+
     // Ensures that a fuzzed address input does not match a known contract address
     function _assumeClean(address a) internal {
         assumeNoPrecompiles(a);


### PR DESCRIPTION
## Motivation

One `StorageRent` fuzz test is failing whenever `0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9` is one of the fuzzed addresses. (See https://github.com/farcasterxyz/contracts/issues/239). This is the address of the `StorageRent` contract itself.

## Change Summary

- Use the existing `TestSuiteSetup` helper, which registers known contract addresses and provides a helper for excluding them in fuzz runs.
- Add an `addKnownContract` helper to register additional known contract addresses in test `setUp`.
- Exclude known addresses from fuzz runs.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Close #239

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding known contract addresses and ensuring clean addresses in the StorageRentTest contract. 

### Detailed summary
- Added `addKnownContract` function to mark contract addresses as known
- Added `_assumeClean` function to ensure clean addresses in the StorageRentTest contract

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->