### PR TITLE
fix: cleanup slither warnings

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,4 @@
 {
-  "detectors_to_exclude": "assembly-usage, block-timestamp, conformance-to-solidity-naming-conventions, incorrect-versions-of-solidity",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -101,6 +101,7 @@ contract Bundler is Ownable2Step {
         // Do not allow anyone except the Farcaster Bootstrap Server (trustedCaller) to call this
         if (msg.sender != trustedCaller) revert Unauthorized();
 
+        // Safety: calls inside a loop are safe since caller is trusted
         for (uint256 i = 0; i < users.length; i++) {
             uint256 fid = idRegistry.trustedRegister(users[i].to, recovery);
             storageRent.credit(fid, users[i].units);

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -73,10 +73,10 @@ contract Bundler is Ownable2Step {
      */
     function register(address to, address recovery, uint256 storageUnits) external payable {
         uint256 fid = idRegistry.register(to, recovery);
-        storageRent.rent{value: msg.value}(fid, storageUnits);
+        uint256 overpayment = storageRent.rent{value: msg.value}(fid, storageUnits);
 
-        if (address(this).balance > 0) {
-            _sendNative(msg.sender, address(this).balance);
+        if (overpayment > 0) {
+            _sendNative(msg.sender, overpayment);
         }
     }
 

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -142,17 +142,17 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
         bytes calldata response,
         bytes calldata /* extraData */
     ) external view returns (bytes memory) {
-        (string memory fname, uint256 timestamp, address owner, bytes memory signature) =
+        (string memory fname, uint256 timestamp, address fnameOwner, bytes memory signature) =
             abi.decode(response, (string, uint256, address, bytes));
 
         bytes32 proofHash =
-            keccak256(abi.encode(_USERNAME_PROOF_TYPEHASH, keccak256(abi.encodePacked(fname)), timestamp, owner));
+            keccak256(abi.encode(_USERNAME_PROOF_TYPEHASH, keccak256(abi.encodePacked(fname)), timestamp, fnameOwner));
         bytes32 eip712hash = _hashTypedDataV4(proofHash);
         address signer = ECDSA.recover(eip712hash, signature);
 
         if (!signers[signer]) revert InvalidSigner();
 
-        return abi.encode(owner);
+        return abi.encode(fnameOwner);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/StorageRent.sol
+++ b/src/StorageRent.sol
@@ -66,6 +66,9 @@ contract StorageRent is AccessControlEnumerable {
     /// @dev Revert if the caller does not have an authorized role.
     error Unauthorized();
 
+    /// @dev Revert if transferred to the zero address.
+    error InvalidAddress();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -606,6 +609,7 @@ contract StorageRent is AccessControlEnumerable {
      * @param vaultAddr The new vault address.
      */
     function setVault(address vaultAddr) external onlyAdmin {
+        if (vaultAddr == address(0)) revert InvalidAddress();
         emit SetVault(vault, vaultAddr);
         vault = vaultAddr;
     }

--- a/src/StorageRent.sol
+++ b/src/StorageRent.sol
@@ -328,7 +328,7 @@ contract StorageRent is AccessControlEnumerable {
      * @param fid   The fid that will receive the storage allocation.
      * @param units Number of storage units to rent.
      */
-    function rent(uint256 fid, uint256 units) external payable whenNotDeprecated {
+    function rent(uint256 fid, uint256 units) external payable whenNotDeprecated returns (uint256 overpayment) {
         // Checks
         if (units == 0) revert InvalidAmount();
         if (rentedUnits + units > maxUnits) revert ExceedsCapacity();
@@ -340,8 +340,10 @@ contract StorageRent is AccessControlEnumerable {
         emit Rent(msg.sender, fid, units);
 
         // Interactions
-        if (msg.value > totalPrice) {
-            _sendNative(msg.sender, msg.value - totalPrice);
+        // Safety: overpayment is guaranteed to be >=0 because of checks
+        overpayment = msg.value - totalPrice;
+        if (overpayment > 0) {
+            _sendNative(msg.sender, overpayment);
         }
     }
 

--- a/test/StorageRent/StorageRent.t.sol
+++ b/test/StorageRent/StorageRent.t.sol
@@ -1218,6 +1218,17 @@ contract StorageRentTest is StorageRentTestSuite {
                                 SET VAULT
     //////////////////////////////////////////////////////////////*/
 
+    function testFuzzSetVault(address newVault) public {
+        vm.assume(newVault != address(0));
+        vm.expectEmit(false, false, false, true);
+        emit SetVault(vault, newVault);
+
+        vm.prank(admin);
+        storageRent.setVault(newVault);
+
+        assertEq(storageRent.vault(), newVault);
+    }
+
     function testFuzzOnlyAdminCanSetVault(address caller, address vault) public {
         vm.assume(caller != admin);
 
@@ -1226,14 +1237,10 @@ contract StorageRentTest is StorageRentTestSuite {
         storageRent.setVault(vault);
     }
 
-    function testFuzzSetVault(address newVault) public {
-        vm.expectEmit(false, false, false, true);
-        emit SetVault(vault, newVault);
-
+    function testSetVaultCannotBeZeroAddress() public {
         vm.prank(admin);
-        storageRent.setVault(newVault);
-
-        assertEq(storageRent.vault(), newVault);
+        vm.expectRevert(StorageRent.InvalidAddress.selector);
+        storageRent.setVault(address(0));
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

Cleanup warning produced by slither ahead of audit.

## Change Summary

See PR Codex report below for details.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on making several changes and improvements to the codebase.

### Detailed summary:
- Updated variable name `owner` to `fnameOwner` in the `FnameResolver.sol` file.
- Modified the calculation of overpayment in the `Bundler.sol` file.
- Added a loop safety comment in the `Bundler.sol` file.
- Added a new function `testFuzzSetVault` in the `StorageRentTest.t.sol` file.
- Added a new error `InvalidAddress` in the `StorageRent.sol` file.
- Modified the `rent` function in the `StorageRent.sol` file to return the `overpayment` value.
- Added a check for the zero address in the `setVault` function in the `StorageRent.sol` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->