### PR TITLE
chore: use forge fmt --check to fail hook correctly

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "forge fmt && forge snapshot --check --match-contract Gas && forge test -vvv"
+pre-commit = "forge fmt --check && forge snapshot --check --match-contract Gas && forge test -vvv"
 
 [logging]
 verbose = true


### PR DESCRIPTION
## Motivation

The current hook runs the `forge fmt` without `--check` which formats files with issues silently, but doesn't check them in causing CI to fail when pushed later. 

## Change Summary

Change to fail loudly when committing if the any files have formatting issues, so that they must be fixed before a commit is made. 

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the pre-commit command in `.rusty-hook.toml` to include the `--check` flag for `forge fmt`, ensuring code formatting is checked. Additionally, the `verbose` flag is set to true in the `[logging]` section. 

### Detailed summary
- Updated pre-commit command to include `--check` flag for `forge fmt`
- Set `verbose` flag to true in `[logging]` section

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->