### PR TITLE
refactor(Bundler): clean up documentation, parameter names and types

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 933777)
-IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 803837)
+IdRegistryGasUsageTest:testGasRegisterAndRecover() (gas: 933249)
+IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 804430)

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -44,6 +44,7 @@ contract Bundler is Ownable2Step {
     struct UserData {
         address to;
         uint256 units;
+        address recovery;
     }
 
     /**
@@ -123,13 +124,13 @@ contract Bundler is Ownable2Step {
      *
      * @param users  Array of UserData structs to register
      */
-    function trustedBatchRegister(UserData[] calldata users, address recovery) external {
+    function trustedBatchRegister(UserData[] calldata users) external {
         // Do not allow anyone except the Farcaster Bootstrap Server (trustedCaller) to call this
         if (msg.sender != trustedCaller) revert Unauthorized();
 
         // Safety: calls inside a loop are safe since caller is trusted
         for (uint256 i = 0; i < users.length; i++) {
-            uint256 fid = idRegistry.trustedRegister(users[i].to, recovery);
+            uint256 fid = idRegistry.trustedRegister(users[i].to, users[i].recovery);
             storageRent.credit(fid, users[i].units);
         }
     }

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -27,8 +27,14 @@ contract Bundler is Ownable2Step {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Emit when the trustedCaller is changed by the owner after the contract is deployed.
-    event ChangeTrustedCaller(address indexed trustedCaller, address indexed owner);
+    /**
+     * @dev Emit an event when the trustedCaller is set
+     *
+     * @param oldCaller The previous trusted caller.
+     * @param newCaller The new trusted caller.
+     * @param owner The address of the owner making the change.
+     */
+    event SetTrustedCaller(address indexed oldCaller, address indexed newCaller, address owner);
 
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
@@ -59,12 +65,13 @@ contract Bundler is Ownable2Step {
      *
      * @param _idRegistry The address of the IdRegistry contract
      * @param _storageRent The address of the StorageRent contract
-     * @param _trustedCaller The address that can call trustedRegister and partialTrustedRegister
+     * @param _trustedCaller The address that can call trustedRegister and trustedBatchRegister
      */
     constructor(address _idRegistry, address _storageRent, address _trustedCaller) Ownable2Step() {
         idRegistry = IdRegistry(_idRegistry);
         storageRent = StorageRent(_storageRent);
         trustedCaller = _trustedCaller;
+        emit SetTrustedCaller(address(0), _trustedCaller, msg.sender);
     }
 
     /**
@@ -111,11 +118,10 @@ contract Bundler is Ownable2Step {
     /**
      * @notice Change the trusted caller that can call trustedRegister functions
      */
-    function changeTrustedCaller(address _trustedCaller) external onlyOwner {
+    function setTrustedCaller(address _trustedCaller) external onlyOwner {
         if (_trustedCaller == address(0)) revert InvalidAddress();
-
+        emit SetTrustedCaller(trustedCaller, _trustedCaller, msg.sender);
         trustedCaller = _trustedCaller;
-        emit ChangeTrustedCaller(_trustedCaller, msg.sender);
     }
 
     /**

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -77,7 +77,7 @@ contract IdRegistry is ERC2771Context, Ownable2Step, Pausable {
      *
      * @param trustedCaller The address of the new trusted caller.
      */
-    event ChangeTrustedCaller(address indexed trustedCaller);
+    event SetTrustedCaller(address indexed trustedCaller);
 
     /**
      * @dev Emit an event when the trusted only state is disabled.
@@ -273,11 +273,11 @@ contract IdRegistry is ERC2771Context, Ownable2Step, Pausable {
      *
      * @param _trustedCaller The address of the new trusted caller
      */
-    function changeTrustedCaller(address _trustedCaller) external onlyOwner {
+    function setTrustedCaller(address _trustedCaller) external onlyOwner {
         if (_trustedCaller == address(0)) revert InvalidAddress();
 
         trustedCaller = _trustedCaller;
-        emit ChangeTrustedCaller(_trustedCaller);
+        emit SetTrustedCaller(_trustedCaller);
     }
 
     /**

--- a/test/IdRegistry/IdRegistry.gas.t.sol
+++ b/test/IdRegistry/IdRegistry.gas.t.sol
@@ -27,7 +27,7 @@ contract IdRegistryGasUsageTest is IdRegistryTestSuite {
     }
 
     function testGasRegisterFromTrustedCaller() public {
-        idRegistry.changeTrustedCaller(TRUSTED_SENDER);
+        idRegistry.setTrustedCaller(TRUSTED_SENDER);
 
         for (uint256 i = 0; i < 25; i++) {
             address alice = address(uint160(i));

--- a/test/IdRegistry/IdRegistry.owner.t.sol
+++ b/test/IdRegistry/IdRegistry.owner.t.sol
@@ -13,7 +13,7 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    event ChangeTrustedCaller(address indexed trustedCaller);
+    event SetTrustedCaller(address indexed trustedCaller);
     event DisableTrustedOnly();
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -21,32 +21,32 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
                              TRUSTED CALLER
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzChangeTrustedCaller(address alice) public {
+    function testFuzzSetTrustedCaller(address alice) public {
         vm.assume(alice != FORWARDER && alice != address(0));
         assertEq(idRegistry.owner(), owner);
 
         vm.expectEmit(true, true, true, true);
-        emit ChangeTrustedCaller(alice);
-        idRegistry.changeTrustedCaller(alice);
+        emit SetTrustedCaller(alice);
+        idRegistry.setTrustedCaller(alice);
         assertEq(idRegistry.getTrustedCaller(), alice);
     }
 
-    function testFuzzCannotChangeTrustedCallerToZeroAddr() public {
+    function testFuzzCannotSetTrustedCallerToZeroAddr() public {
         assertEq(idRegistry.owner(), owner);
 
         vm.expectRevert(IdRegistry.InvalidAddress.selector);
-        idRegistry.changeTrustedCaller(address(0));
+        idRegistry.setTrustedCaller(address(0));
 
         assertEq(idRegistry.getTrustedCaller(), address(0));
     }
 
-    function testFuzzCannotChangeTrustedCallerUnlessOwner(address alice, address bob) public {
+    function testFuzzCannotSetTrustedCallerUnlessOwner(address alice, address bob) public {
         vm.assume(alice != FORWARDER && bob != address(0));
         vm.assume(idRegistry.owner() != alice);
 
         vm.prank(alice);
         vm.expectRevert("Ownable: caller is not the owner");
-        idRegistry.changeTrustedCaller(bob);
+        idRegistry.setTrustedCaller(bob);
         assertEq(idRegistry.getTrustedCaller(), address(0));
     }
 

--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -89,7 +89,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
     function testFuzzTrustedRegister(address alice, address trustedCaller, address recovery) public {
         vm.assume(trustedCaller != FORWARDER && trustedCaller != address(0));
         vm.assume(recovery != FORWARDER);
-        idRegistry.changeTrustedCaller(trustedCaller);
+        idRegistry.setTrustedCaller(trustedCaller);
         assertEq(idRegistry.getIdCounter(), 0);
 
         vm.prank(trustedCaller);
@@ -128,7 +128,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
         vm.assume(untrustedCaller != FORWARDER && recovery != FORWARDER);
         vm.assume(untrustedCaller != trustedCaller);
         vm.assume(trustedCaller != address(0));
-        idRegistry.changeTrustedCaller(trustedCaller);
+        idRegistry.setTrustedCaller(trustedCaller);
 
         vm.prank(untrustedCaller);
         vm.expectRevert(IdRegistry.Unauthorized.selector);
@@ -145,7 +145,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
         address recovery
     ) public {
         vm.assume(trustedCaller != FORWARDER && trustedCaller != address(0));
-        idRegistry.changeTrustedCaller(trustedCaller);
+        idRegistry.setTrustedCaller(trustedCaller);
 
         vm.prank(trustedCaller);
         idRegistry.trustedRegister(alice, address(0));
@@ -163,7 +163,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
     function testFuzzCannotTrustedRegisterWhenPaused(address alice, address trustedCaller, address recovery) public {
         vm.assume(trustedCaller != FORWARDER && trustedCaller != address(0));
         vm.assume(recovery != FORWARDER);
-        idRegistry.changeTrustedCaller(trustedCaller);
+        idRegistry.setTrustedCaller(trustedCaller);
         assertEq(idRegistry.getIdCounter(), 0);
 
         _pauseRegistrations();


### PR DESCRIPTION
## Motivation

Make Bundler contract easier to audit and understand, improve trustedBatchRegister functionality to cover all migration types.

## Change Summary

See PR Codex below for a full list of changes.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the function name `changeTrustedCaller` to `setTrustedCaller` in the `IdRegistry` and `Bundler` contracts. It also updates the corresponding event names and adds a `recovery` parameter to the `UserData` struct. 

### Detailed summary
- Renamed `changeTrustedCaller` function to `setTrustedCaller` in `IdRegistry` and `Bundler` contracts.
- Updated event names from `ChangeTrustedCaller` to `SetTrustedCaller` in `IdRegistry` and `Bundler` contracts.
- Added `recovery` parameter to `UserData` struct in `Bundler` contract.

> The following files were skipped due to too many changes: `src/Bundler.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->