### PR TITLE
chore: review, disable, and document Slither detectors.

### DIFF
--- a/src/lib/TransferHelper.sol
+++ b/src/lib/TransferHelper.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+library TransferHelper {
+    /// @dev Revert when a native token transfer fails.
+    error CallFailed();
+
+    /// @dev Revert when there are not enough funds for a native token transfer.
+    error InsufficientFunds();
+
+    /**
+     * @dev Native token transfer helper.
+     */
+    function sendNative(address to, uint256 amount) internal {
+        if (address(this).balance < amount) revert InsufficientFunds();
+
+        /**
+         *  This Slither detector requires all return values to be
+         *  used, but we are intentionally ignoring returndata here.
+         *  This is safe since we still check success and revert if
+         *  the call failed. We're not using the returndata.
+         */
+
+        // slither-disable-next-line unchecked-lowlevel, unused-return
+        (bool success,) = payable(to).call{value: amount}("");
+        if (!success) revert CallFailed();
+    }
+}

--- a/test/StorageRent/StorageRent.t.sol
+++ b/test/StorageRent/StorageRent.t.sol
@@ -7,6 +7,7 @@ import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 import "../TestConstants.sol";
 
 import {StorageRent} from "../../src/StorageRent.sol";
+import {TransferHelper} from "../../src/lib/TransferHelper.sol";
 import {StorageRentTestSuite} from "./StorageRentTestSuite.sol";
 import {MockChainlinkFeed} from "../Utils.sol";
 
@@ -315,7 +316,7 @@ contract StorageRentTest is StorageRentTestSuite {
         vm.deal(address(revertOnReceive), price + extra);
 
         vm.prank(address(revertOnReceive));
-        vm.expectRevert(StorageRent.CallFailed.selector);
+        vm.expectRevert(TransferHelper.CallFailed.selector);
         storageRent.rent{value: price + extra}(id, units);
     }
 
@@ -667,7 +668,7 @@ contract StorageRentTest is StorageRentTestSuite {
 
         vm.deal(address(revertOnReceive), value);
         vm.prank(address(revertOnReceive));
-        vm.expectRevert(StorageRent.CallFailed.selector);
+        vm.expectRevert(TransferHelper.CallFailed.selector);
         storageRent.batchRent{value: value}(ids, units);
     }
 
@@ -1272,7 +1273,7 @@ contract StorageRentTest is StorageRentTestSuite {
         amount = bound(amount, 1, type(uint256).max);
 
         vm.prank(treasurer);
-        vm.expectRevert(StorageRent.InsufficientFunds.selector);
+        vm.expectRevert(TransferHelper.InsufficientFunds.selector);
         storageRent.withdraw(amount);
     }
 
@@ -1284,7 +1285,7 @@ contract StorageRentTest is StorageRentTestSuite {
         storageRent.setVault(address(revertOnReceive));
 
         vm.prank(treasurer);
-        vm.expectRevert(StorageRent.CallFailed.selector);
+        vm.expectRevert(TransferHelper.CallFailed.selector);
         storageRent.withdraw(price);
     }
 


### PR DESCRIPTION
## Motivation

Slither is very useful, but sometimes flags false positives. It's possible to disable specific Slither detectors using inline comments, and it's a good idea to explain why disabling the detector is safe. Our latest contracts contain a few lines that are either false positives or safe in context. 

## Change Summary

- Disable specific Slither detectors and add explanatory comments.
- Refactor to use a new `TransferHelper` library for native token transfers. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context
Adds a new `TransferHelper` library for native token transfers. Our `_sendNative` function is very similar to OZ `Address.sendValue`, but uses custom errors. This is lighter weight than pulling in OZ `Address` and lets us keep using custom errors, but we could just as easily import and use the OZ library if we want. 

Although this is only the second strike in terms of duplication, it felt wrong to copy-paste the explanation and Slither comment across multiple files. 

Close #244 and #245 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a `TransferHelper` library and using it in the `Bundler` and `StorageRent` contracts for native token transfers.

### Detailed summary:
- Added `TransferHelper` library for native token transfers.
- Used `TransferHelper` in the `Bundler` and `StorageRent` contracts for native token transfers.
- Replaced calls to `sendNative` with `TransferHelper.sendNative` in the `Bundler` contract.
- Replaced calls to `sendNative` with `TransferHelper.sendNative` in the `StorageRent` contract.
- Removed the `_sendNative` function from the `Bundler` and `StorageRent` contracts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->