### PR TITLE
Add OZ ERC2771 forwarder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/openzeppelin-latest"]
+	path = lib/openzeppelin-latest
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ fuzz = { runs = 512 }
 remappings = [
   "solmate/=lib/solmate/",
   "openzeppelin/=lib/openzeppelin-contracts/",
+  "openzeppelin-latest/=lib/openzeppelin-latest/",
   "chainlink/=lib/chainlink-brownie-contracts/contracts/src/"
 ]
 

--- a/src/Forwarder.sol
+++ b/src/Forwarder.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {ERC2771Forwarder} from "openzeppelin-latest/contracts/metatx/ERC2771Forwarder.sol";
+
+contract Forwarder is ERC2771Forwarder {
+    constructor(string memory name) ERC2771Forwarder(name) {}
+}


### PR DESCRIPTION
## Motivation

OpenZeppelin's `MinimalForwarder` is not recommended for production use, but a production-ready `ERC7221Forwarder` was recently added to latest OZ.

## Change Summary

Add `Forwarder`, based on the new OpenZeppelin `ERC7221Forwarder`.  Update metatx tests to use `Forwarder` rather than `MinimalForwarder`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Close #249 


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the OpenZeppelin contracts submodule and making changes to the Forwarder contract.

### Detailed summary:
- Added a new submodule `openzeppelin-latest` with commit `7ccea54dc15856d0e6c3b61b829b85d9e52195cd`
- Updated the import statement in the `Forwarder.sol` file to use `ERC2771Forwarder` from the `openzeppelin-latest` submodule
- Updated the import statement in the `IdRegistry.metatx.t.sol` test file to use `ERC2771Forwarder` from the `openzeppelin-latest` submodule
- Changed the constructor call in the `setUp` function of the `IdRegistryMetaTxTest` contract to use the `Forwarder` contract instead of `MinimalForwarder`
- Updated the `_signReq` function in the `IdRegistryMetaTxTest` contract to match the changes in the `ForwardRequest` struct from `MinimalForwarder` to `ERC2771Forwarder.ForwardRequestData`
- Updated the `_domainSeparator` function in the `IdRegistryMetaTxTest` contract to use the name "Farcaster Forwarder" for the domain separator

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->