### PR TITLE
chore: remove unused Forwarder contract

### DIFF
--- a/src/Forwarder.sol
+++ b/src/Forwarder.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
-
-import {ERC2771Forwarder} from "openzeppelin-latest/contracts/metatx/ERC2771Forwarder.sol";
-
-contract Forwarder is ERC2771Forwarder {
-    constructor(string memory name) ERC2771Forwarder(name) {}
-}


### PR DESCRIPTION
## Motivation

Remove unused code

## Change Summary

The Forwarder contract is no longer needed since meta-tx support was removed in #257 

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The file `Forwarder.sol` has been deleted.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->