### PR TITLE
fix(KeyRegistry): prevent add for zero fid

### DIFF
--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -327,6 +327,7 @@ contract KeyRegistry is Ownable2Step {
     //////////////////////////////////////////////////////////////*/
 
     function _add(uint256 fid, uint32 scheme, bytes calldata key, bytes calldata metadata) internal {
+        if (fid == 0) revert Unauthorized();
         KeyData storage keyData = keys[fid][key];
         if (keyData.state != KeyState.NULL) revert InvalidState();
 

--- a/test/KeyRegistry/KeyRegistry.t.sol
+++ b/test/KeyRegistry/KeyRegistry.t.sol
@@ -54,6 +54,19 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertAdded(fid, key, scheme);
     }
 
+    function testFuzzRegisterRevertsFidZero(
+        address caller,
+        uint32 scheme,
+        bytes calldata key,
+        bytes calldata metadata
+    ) public {
+        vm.prank(caller);
+        vm.expectRevert(KeyRegistry.Unauthorized.selector);
+        keyRegistry.add(0, scheme, key, metadata);
+
+        assertNull(0, key);
+    }
+
     function testFuzzRegisterRevertsUnlessFidOwner(
         address to,
         address recovery,
@@ -561,7 +574,7 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                     break;
                 }
             }
-            if (!found) {
+            if (!found && _ids[i] != 0) {
                 ids[idsLength++] = _ids[i];
             }
         }


### PR DESCRIPTION
## Motivation

Prevent key registrations to the zero fid. See #272.

## Change Summary

Revert in `_add` if `fid` is zero.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Close #272 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on adding a new function `testFuzzRegisterRevertsFidZero` to the `KeyRegistry` contract. Notable changes include:

- Addition of the `testFuzzRegisterRevertsFidZero` function in `KeyRegistry.t.sol`
- Implementation of the `_add` function in `KeyRegistry.sol` with a check for unauthorized access

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->