### PR TITLE
fix(StorageRent): remove noop revokeRole

### DIFF
--- a/src/StorageRent.sol
+++ b/src/StorageRent.sol
@@ -310,8 +310,6 @@ contract StorageRent is AccessControlEnumerable {
         _grantRole(OPERATOR_ROLE, _initialOperator);
         _grantRole(TREASURER_ROLE, _initialTreasurer);
 
-        _revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
-
         _refreshPrice();
     }
 


### PR DESCRIPTION
## Motivation

This line in the `StorageRent` constructor is a no-op: `msg.sender` is not ever granted the `DEFAULT_ADMIN_ROLE`, so revoking it here does nothing.

## Change Summary

Remove the no-op line.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on granting the `TREASURER_ROLE` to the `_initialTreasurer` and revoking the `DEFAULT_ADMIN_ROLE` from `msg.sender`. 

### Detailed summary
- Grant the `TREASURER_ROLE` to the `_initialTreasurer`.
- Revoke the `DEFAULT_ADMIN_ROLE` from `msg.sender`.
- Refresh the price.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->