### PR TITLE
chore: upgrade solidity to 0.8.21, keep evm_version at paris

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
-solc_version = "0.8.19"
+solc_version = "0.8.21"
+evm_version = "paris"
 optimizer_runs = 100_000
 fuzz = { runs = 512 }
 remappings = [

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";

--- a/script/FnameResolver.s.sol
+++ b/script/FnameResolver.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Script.sol";
 

--- a/script/IdRegistry.s.sol
+++ b/script/IdRegistry.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Script.sol";
 import {IdRegistry} from "../src/IdRegistry.sol";

--- a/script/StorageRent.s.sol
+++ b/script/StorageRent.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Script.sol";
 import {AggregatorV3Interface} from "chainlink/v0.8/interfaces/AggregatorV3Interface.sol";

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
 

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
 import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Context} from "openzeppelin/contracts/utils/Context.sol";
 import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
 import {IdRegistry} from "./IdRegistry.sol";

--- a/src/StorageRent.sol
+++ b/src/StorageRent.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {AggregatorV3Interface} from "chainlink/v0.8/interfaces/AggregatorV3Interface.sol";
 import {AccessControlEnumerable} from "openzeppelin/contracts/access/AccessControlEnumerable.sol";

--- a/src/lib/TransferHelper.sol
+++ b/src/lib/TransferHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 library TransferHelper {
     /// @dev Revert when a native token transfer fails.

--- a/test/Bundler/Bundler.gas.t.sol
+++ b/test/Bundler/Bundler.gas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 

--- a/test/Bundler/Bundler.t.sol
+++ b/test/Bundler/Bundler.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Bundler} from "../../src/Bundler.sol";
 import {IdRegistry} from "../../src/IdRegistry.sol";

--- a/test/Bundler/BundlerTestSuite.sol
+++ b/test/Bundler/BundlerTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "../TestConstants.sol";
 

--- a/test/FnameResolver/FnameResolverTestSuite.sol
+++ b/test/FnameResolver/FnameResolverTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
 

--- a/test/IdRegistry/IdRegistry.gas.t.sol
+++ b/test/IdRegistry/IdRegistry.gas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {IdRegistryTestSuite} from "./IdRegistryTestSuite.sol";
 import {IdRegistryHarness} from "../Utils.sol";

--- a/test/IdRegistry/IdRegistryTestSuite.sol
+++ b/test/IdRegistry/IdRegistryTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {IdRegistryHarness} from "../Utils.sol";
 import {TestSuiteSetup} from "../TestSuiteSetup.sol";

--- a/test/KeyRegistry/KeyRegistryTestSuite.sol
+++ b/test/KeyRegistry/KeyRegistryTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 

--- a/test/StorageRent/StorageRentTestSuite.sol
+++ b/test/StorageRent/StorageRentTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {StorageRentHarness, MockPriceFeed, MockUptimeFeed, MockChainlinkFeed, RevertOnReceive} from "../Utils.sol";
 import {TestSuiteSetup} from "../TestSuiteSetup.sol";

--- a/test/TestConstants.sol
+++ b/test/TestConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 // When fuzzing, concern ourselves with functionality for the next 100 years
 uint256 constant FUZZ_TIME_PERIOD = 100 * 365.25 days;

--- a/test/TestSuiteSetup.sol
+++ b/test/TestSuiteSetup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.19;
+pragma solidity 0.8.21;
 
 import {AggregatorV3Interface} from "chainlink/v0.8/interfaces/AggregatorV3Interface.sol";
 


### PR DESCRIPTION
## Motivation

Upgrade to the newer solidity version so we can take advantage of new features like importing events. Pin the evm version to paris, since shanghai's push0 isn't supported by many l2s. 

## Change Summary

- Upgrade solidity to 0.8.21
- Pin evm_version to paris

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
