### PR TITLE
chore: coverage fixups

### DIFF
--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -44,6 +44,15 @@ contract FnameResolverTest is FnameResolverTestSuite {
         resolver.resolve(name, data);
     }
 
+    function testFuzzResolveRevertsNonAddrFunction(bytes calldata name, bytes memory data) public {
+        data = bytes.concat(hex"00000001", data);
+        string[] memory urls = new string[](1);
+        urls[0] = FNAME_SERVER_URL;
+
+        vm.expectRevert(FnameResolver.ResolverFunctionNotSupported.selector);
+        resolver.resolve(name, data);
+    }
+
     function testFuzzResolveWithProofValidSignature(string memory name, uint256 timestamp, address owner) public {
         bytes memory signature = _signProof(name, timestamp, owner);
         bytes memory extraData = abi.encodeCall(IResolverService.resolve, (DNS_ENCODED_NAME, ADDR_QUERY_CALLDATA));

--- a/test/StorageRent/StorageRent.t.sol
+++ b/test/StorageRent/StorageRent.t.sol
@@ -8,7 +8,7 @@ import "../TestConstants.sol";
 
 import {StorageRent} from "../../src/StorageRent.sol";
 import {TransferHelper} from "../../src/lib/TransferHelper.sol";
-import {StorageRentTestSuite} from "./StorageRentTestSuite.sol";
+import {StorageRentTestSuite, StorageRentHarness} from "./StorageRentTestSuite.sol";
 import {MockChainlinkFeed} from "../Utils.sol";
 
 /* solhint-disable state-visibility */
@@ -107,6 +107,23 @@ contract StorageRentTest is StorageRentTestSuite {
 
     function testInitialUnitPrice() public {
         assertEq(storageRent.unitPrice(), INITIAL_PRICE_IN_ETH);
+    }
+
+    function testInitialPriceUpdate() public {
+        // Clear ethUsdPrice storage slot
+        vm.store(address(storageRent), bytes32(uint256(11)), bytes32(0));
+        assertEq(storageRent.ethUsdPrice(), 0);
+
+        // Clear prevEthUsdPrice storage slot
+        vm.store(address(storageRent), bytes32(uint256(12)), bytes32(0));
+        assertEq(storageRent.prevEthUsdPrice(), 0);
+
+        vm.prank(admin);
+        storageRent.refreshPrice();
+
+        assertEq(storageRent.ethUsdPrice(), uint256(ETH_USD_PRICE));
+        assertEq(storageRent.prevEthUsdPrice(), uint256(ETH_USD_PRICE));
+        assertEq(storageRent.ethUsdPrice(), storageRent.prevEthUsdPrice());
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

Recent coverage reports show a couple uncovered lines in `StorageRent` and `FnameResolver`.

## Change Summary

Add a test for the selector check in `FnameResolver` and the initial price update in `StorageRent`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new test function `testFuzzResolveRevertsNonAddrFunction` and updating an existing test function `testInitialPriceUpdate`.

### Detailed summary:
- Added a new test function `testFuzzResolveRevertsNonAddrFunction` in the `FnameResolver` contract.
- Updated the `testInitialPriceUpdate` function in the `StorageRent` contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->