### PR TITLE
feat(KeyRegistry): add settable IdRegistry

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,6 +1,6 @@
 BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 826205)
-BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 6732822)
-BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 849451)
+BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 6744222)
+BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 852391)
 IdRegistryGasUsageTest:testGasRegister() (gas: 734576)
 IdRegistryGasUsageTest:testGasRegisterForAndRecover() (gas: 1702036)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 808056)

--- a/test/KeyRegistry/KeyRegistry.t.sol
+++ b/test/KeyRegistry/KeyRegistry.t.sol
@@ -21,6 +21,7 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     event Remove(uint256 indexed fid, bytes indexed key, bytes keyBytes);
     event AdminReset(uint256 indexed fid, bytes indexed key, bytes keyBytes);
     event Migrated(uint256 indexed keysMigratedAt);
+    event SetIdRegistry(address oldIdRegistry, address newIdRegistry);
 
     function testInitialIdRegistry() public {
         assertEq(address(keyRegistry.idRegistry()), address(idRegistry));
@@ -852,6 +853,30 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.bulkResetKeysForMigration(ids, keys);
 
         vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           SET IDREGISTRY
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzzOnlyAdminCanSetIdRegistry(address caller, address idRegistry) public {
+        vm.assume(caller != owner);
+
+        vm.prank(caller);
+        vm.expectRevert("Ownable: caller is not the owner");
+        keyRegistry.setIdRegistry(idRegistry);
+    }
+
+    function testFuzzSetIdRegistry(address idRegistry) public {
+        address currentIdRegistry = address(keyRegistry.idRegistry());
+
+        vm.expectEmit(false, false, false, true);
+        emit SetIdRegistry(currentIdRegistry, idRegistry);
+
+        vm.prank(owner);
+        keyRegistry.setIdRegistry(idRegistry);
+
+        assertEq(address(keyRegistry.idRegistry()), idRegistry);
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

The `KeyRegistry` contract `owner` should be able to update the `IdRegistry` address, in case of a future upgrade.

## Change Summary

Use a minimal interface for `IdRegistry` in `KeyRegistry`. Add an authenticated setter function. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Close #264 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The gas usage for two functions in the `BundleRegistryGasUsageTest` contract has increased.
- The gas usage for two functions in the `IdRegistryGasUsageTest` contract remains the same.
- An event `SetIdRegistry` has been added to the `KeyRegistry` contract.
- Two new functions `testFuzzOnlyAdminCanSetIdRegistry` and `testFuzzSetIdRegistry` have been added to the `KeyRegistryTest` contract.
- The `KeyRegistry` contract now uses the `IdRegistryLike` interface instead of the `IdRegistry` contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->