### PR TITLE
perf(Bundler): reduce gas usage w/ `unchecked` increments in batch fn loops and cached `user` value

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,5 +1,5 @@
 BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 826205)
-BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 6744222)
+BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 6646422)
 BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 852391)
 IdRegistryGasUsageTest:testGasRegister() (gas: 734576)
 IdRegistryGasUsageTest:testGasRegisterForAndRecover() (gas: 1702036)

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -109,9 +109,14 @@ contract Bundler is TrustedCaller {
         uint256 fid =
             idRegistry.registerFor(registration.to, registration.recovery, registration.deadline, registration.sig);
 
-        for (uint256 i; i < signers.length; i++) {
+        for (uint256 i; i < signers.length;) {
             SignerParams calldata signer = signers[i];
             keyRegistry.addFor(registration.to, signer.scheme, signer.key, signer.metadata, signer.deadline, signer.sig);
+
+            // We know this will not overflow because it's less than the length of the array, which is a `uint256`.
+            unchecked {
+                ++i;
+            }
         }
 
         uint256 overpayment = storageRent.rent{value: msg.value}(fid, storageUnits);
@@ -152,10 +157,16 @@ contract Bundler is TrustedCaller {
      */
     function trustedBatchRegister(UserData[] calldata users) external onlyTrustedCaller {
         // Safety: calls inside a loop are safe since caller is trusted
-        for (uint256 i = 0; i < users.length; i++) {
-            uint256 fid = idRegistry.trustedRegister(users[i].to, users[i].recovery);
-            keyRegistry.trustedAdd(users[i].to, users[i].scheme, users[i].key, users[i].metadata);
-            storageRent.credit(fid, users[i].units);
+        for (uint256 i; i < users.length;) {
+            UserData calldata user = users[i];
+            uint256 fid = idRegistry.trustedRegister(user.to, user.recovery);
+            keyRegistry.trustedAdd(user.to, user.scheme, user.key, user.metadata);
+            storageRent.credit(fid, user.units);
+
+            // We know this will not overflow because it's less than the length of the array, which is a `uint256`.
+            unchecked {
+                ++i;
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

Remove checks for lists to save gas usage because we know the index can't be incremented greater than an array's length.

## Change Summary

- Add `unchecked` blocks to incrementing loop index in batch functions (`register` and `trustedBatchRegister`)
- Cache `users[i]` w/ `UserData calldata user = users[i]`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on optimizing gas usage in the `BundleRegistryGasUsageTest` and `Bundler` contracts.

### Detailed summary:
- Gas usage in `BundleRegistryGasUsageTest:testGasTrustedBatchRegister()` is reduced from 6,744,222 to 6,646,422.
- Gas usage in `BundleRegistryGasUsageTest:testGasRegister()` is reduced from 852,391 to 734,576.
- Gas usage in `BundleRegistryGasUsageTest:testGasRegisterForAndRecover()` is reduced from 1,702,036 to 1,702,036.
- A comment is added to explain why an increment operation will not overflow.
- Gas usage in `Bundler:trustedBatchRegister()` is optimized by using an unchecked block and reducing gas usage in the loop.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The gas usage for the `testGasTrustedBatchRegister()` function in the `BundleRegistryGasUsageTest` contract has been reduced.
- The gas usage for the `testGasTrustedRegister()` function in the `BundleRegistryGasUsageTest` contract has been reduced.
- The gas usage for the `testGasRegister()` function in the `IdRegistryGasUsageTest` contract has been reduced.
- The gas usage for the `testGasRegisterForAndRecover()` function in the `IdRegistryGasUsageTest` contract has been reduced.
- In the `Bundler.sol` contract, a comment has been added to explain that an increment operation will not overflow.
- In the `Bundler.sol` contract, the `trustedBatchRegister()` function has been optimized to reduce gas usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->