### PR TITLE
docs: update event invariant docs for KeyRegistry, StorageRegistry

### DIFF
--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -69,7 +69,8 @@ contract IdRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
     event Transfer(address indexed from, address indexed to, uint256 indexed id);
 
     /**
-     * @dev Emit an event when a Farcaster ID's recovery address changes.
+     * @dev Emit an event when a Farcaster ID's recovery address changes. It is possible for this
+     *      event to emit multiple times in a row with the same recovery address.
      *
      * @param id       The fid whose recovery address was changed.
      * @param recovery The new recovery address.

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -96,10 +96,10 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      *      keyBytes is marked as removed, messages signed by keyBytes with `fid` are invalid,
      *      dropped immediately and no longer accepted. Hubs assume the invariants:
      *
-     *      1. Remove(fid, key, keyBytes cannot emit if there is no earlier emit with
+     *      1. Remove(fid, key, keyBytes) cannot emit if there is no earlier emit with
      *         Add(fid, ..., key, keyBytes, ...)
      *
-     *      2. Remove(fid, key, keyBytes, ...) cannot emit if there is an earlier emit with
+     *      2. Remove(fid, key, keyBytes) cannot emit if there is an earlier emit with
      *         Remove(fid, key, keyBytes)
      *
      *      3. For all Remove(..., key, keyBytes), key = keccack(keyBytes)
@@ -113,10 +113,14 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
     /**
      * @dev Emit an event when an admin resets an added key.
      *
-     *      Hubs listen for this, validate that keyBytes is an EdDSA pub key, that scheme == 1 and
-     *      that keyBytes exists in its SignerStore. keyBytes is no longer tracked, messages signed
-     *      by keyBytes with `fid` are invalid, dropped immediately and not accepted. Unlike Remove
-     *      keyBytes can be added to the SignerStore if an Add() event is observed.
+     *      Hubs listen for this, validate that scheme == 1 and that keyBytes exists in its SignerStore.
+     *      keyBytes is no longer tracked, messages signed by keyBytes with `fid` are invalid, dropped
+     *      immediately and not accepted. Hubs assume the following invariants:
+     *
+     *      1. AdminReset(fid, key, keyBytes) cannot emit unless the most recent event for the fid
+     *         was Add(fid, ..., key, keyBytes, ...).
+     *
+     *      2. For all AdminReset(..., key, keyBytes), key = keccack(keyBytes)
      *
      * @param fid       The fid associated with the key.
      * @param key       The key being reset. (indexed as hash)

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -120,7 +120,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      *      1. AdminReset(fid, key, keyBytes) cannot emit unless the most recent event for the fid
      *         was Add(fid, ..., key, keyBytes, ...).
      *
-     *      2. For all AdminReset(..., key, keyBytes), key = keccack(keyBytes)
+     *      2. For all AdminReset(..., key, keyBytes), key = keccack(keyBytes).
+     *
+     *      3. AdminReset() cannot emit after Migrated().
      *
      * @param fid       The fid associated with the key.
      * @param key       The key being reset. (indexed as hash)

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -76,8 +76,9 @@ contract StorageRegistry is AccessControlEnumerable {
      * @dev Emit an event when caller pays rent for an fid's storage.
      *
      *      Hubs listen for this event and increment the units assigned to the fid by 1 for exactly
-     *      395 days from the timestamp of this event (1 year + 30 day grace period). Hubs respect
-     *      this even if the fid is not yet issued or invalid (e.g. 0).
+     *      395 days from the timestamp of this event (1 year + 30 day grace period). Hubs track
+     *      this for unregistered fids and will assign storage when the fid is registered. Storage
+     *      credited to fid 0 is a no-op.
      *
      * @param payer     Address of the account paying the storage rent.
      * @param fid       The fid that will receive the storage allocation.
@@ -116,6 +117,12 @@ contract StorageRegistry is AccessControlEnumerable {
 
     /**
      * @dev Emit an event when an owner changes the deprecationTimestamp.
+     *
+     *      Hubs will track this timestamp to determine when the contract is deprecated and the
+     *      next Storage contract should be used. The logic to cutover is still to be determined.
+     *      Hubs assume the following invariants:
+     *
+     *      1. SetDeprecationTimestamp() is only emitted once.
      *
      * @param oldTimestamp The previous deprecationTimestamp.
      * @param newTimestamp The new deprecationTimestamp.


### PR DESCRIPTION
## Motivation

Update documentation based on feedback.

## Change Summary

Updated event invariant documentation

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the documentation in three contracts: `IdRegistry.sol`, `StorageRegistry.sol`, and `KeyRegistry.sol`.

### Detailed summary:
- In `IdRegistry.sol`, the documentation for an event `RecoveryAddressChanged` has been updated to mention that the event can emit multiple times with the same recovery address.
- In `StorageRegistry.sol`, the documentation for an event `StorageRentPaid` has been updated to clarify that storage is credited to unregistered fids and will be assigned when the fid is registered.
- In `StorageRegistry.sol`, the documentation for an event `SetDeprecationTimestamp` has been updated to mention that hubs will track this timestamp to determine when the contract is deprecated.
- In `KeyRegistry.sol`, the documentation for an event `Remove` has been updated to clarify the invariants that hubs assume regarding the order and existence of events.
- In `KeyRegistry.sol`, the documentation for an event `AdminReset` has been updated to clarify the invariants that hubs assume regarding the order and existence of events.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->