### PR TITLE
perf(TransferHelper): remove unnecessary checks and use yul for native token transfer

### DIFF
--- a/src/lib/TransferHelper.sol
+++ b/src/lib/TransferHelper.sol
@@ -5,24 +5,18 @@ library TransferHelper {
     /// @dev Revert when a native token transfer fails.
     error CallFailed();
 
-    /// @dev Revert when there are not enough funds for a native token transfer.
-    error InsufficientFunds();
-
     /**
      * @dev Native token transfer helper.
      */
     function sendNative(address to, uint256 amount) internal {
-        if (address(this).balance < amount) revert InsufficientFunds();
+        bool success;
 
-        /**
-         *  This Slither detector requires all return values to be
-         *  used, but we are intentionally ignoring returndata here.
-         *  This is safe since we still check success and revert if
-         *  the call failed. We're not using the returndata.
-         */
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Transfer the native token and store if it succeeded or not.
+            success := call(gas(), to, amount, 0, 0, 0, 0)
+        }
 
-        // slither-disable-next-line unchecked-lowlevel, unused-return
-        (bool success,) = payable(to).call{value: amount}("");
         if (!success) revert CallFailed();
     }
 }

--- a/test/StorageRegistry/StorageRegistry.t.sol
+++ b/test/StorageRegistry/StorageRegistry.t.sol
@@ -1530,7 +1530,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         amount = bound(amount, 1, type(uint256).max);
 
         vm.prank(treasurer);
-        vm.expectRevert(TransferHelper.InsufficientFunds.selector);
+        vm.expectRevert(TransferHelper.CallFailed.selector);
         storageRegistry.withdraw(amount);
     }
 


### PR DESCRIPTION
## Motivation

Removes an unnecessary check for balance before transferring native tokens (the call would return false if insufficient balance anyway).

## Change Summary

- Remove `InsufficientFunds` check
- Transfer ETH with inline assembly (similar implementation as [**solmate/utils/SafeTransferLib.sol**](https://github.com/transmissions11/solmate/blob/bfc9c25865a274a7827fea5abf6e4fb64fc64e6c/src/utils/SafeTransferLib.sol#L15))

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Not a complex change, but the code should function identical to [**solmate/utils/SafeTransferLib.sol**](https://github.com/transmissions11/solmate/blob/bfc9c25865a274a7827fea5abf6e4fb64fc64e6c/src/utils/SafeTransferLib.sol#L15), which is pretty [**well-tested**](https://github.com/transmissions11/solmate/blob/bfc9c25865a274a7827fea5abf6e4fb64fc64e6c/src/test/SafeTransferLib.t.sol#L18).


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to update the `TransferHelper` contract to use a new error message and to improve the handling of native token transfers.

### Detailed summary:
- Updated the `expectRevert` function in the `StorageRegistry` test file to expect the `CallFailed` error instead of the `InsufficientFunds` error.
- Removed the `InsufficientFunds` error from the `TransferHelper` contract.
- Added a new `CallFailed` error in the `TransferHelper` contract.
- Modified the `sendNative` function in the `TransferHelper` contract to use assembly code for native token transfers and to check the success of the transfer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->