### PR TITLE
chore: Add more comprehensive smart contract wallet tests

### DIFF
--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -7,7 +7,7 @@ import {IdRegistry} from "../../src/IdRegistry.sol";
 import {TrustedCaller} from "../../src/lib/TrustedCaller.sol";
 import {Signatures} from "../../src/lib/Signatures.sol";
 import {IdRegistryTestSuite} from "./IdRegistryTestSuite.sol";
-import {ERC1271WalletMock, ERC1271MaliciousMock} from "../Utils.sol";
+import {ERC1271WalletMock, ERC1271MaliciousMockForceRevert} from "../Utils.sol";
 
 /* solhint-disable state-visibility */
 

--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -929,7 +929,7 @@ contract IdRegistryTest is IdRegistryTestSuite {
     }
 
     /*//////////////////////////////////////////////////////////////
-                          VERIFY FID SIGNATURE EOA
+                        EOA VERIFY FID SIGNATURE
     //////////////////////////////////////////////////////////////*/
 
     function testFuzzVerifyFidSignature(uint256 recipientPk, bytes32 digest) public {

--- a/test/TestSuiteSetup.sol
+++ b/test/TestSuiteSetup.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.21;
 
 import {Test} from "forge-std/Test.sol";
+import {ERC1271WalletMock, ERC1271MaliciousMock} from "./Utils.sol";
 
 abstract contract TestSuiteSetup is Test {
     /*//////////////////////////////////////////////////////////////
@@ -65,5 +66,21 @@ abstract contract TestSuiteSetup is Test {
 
     function _boundDeadline(uint40 deadline) internal view returns (uint256) {
         return block.timestamp + uint256(bound(deadline, 1, type(uint40).max));
+    }
+
+    function _createMockERC1271(address ownerAddress)
+        internal
+        returns (ERC1271WalletMock mockWallet, address mockWalletAddress)
+    {
+        mockWallet = new ERC1271WalletMock(ownerAddress);
+        mockWalletAddress = address(mockWallet);
+    }
+
+    function _createMaliciousMockERC1271(address ownerAddress)
+        internal
+        returns (ERC1271MaliciousMock mockWallet, address mockWalletAddress)
+    {
+        mockWallet = new ERC1271MaliciousMock(ownerAddress);
+        mockWalletAddress = address(mockWallet);
     }
 }

--- a/test/TestSuiteSetup.sol
+++ b/test/TestSuiteSetup.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.21;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC1271WalletMock, ERC1271MaliciousMock} from "./Utils.sol";
+import {ERC1271WalletMock, ERC1271MaliciousMockForceRevert} from "./Utils.sol";
 
 abstract contract TestSuiteSetup is Test {
     /*//////////////////////////////////////////////////////////////
@@ -78,9 +78,9 @@ abstract contract TestSuiteSetup is Test {
 
     function _createMaliciousMockERC1271(address ownerAddress)
         internal
-        returns (ERC1271MaliciousMock mockWallet, address mockWalletAddress)
+        returns (ERC1271MaliciousMockForceRevert mockWallet, address mockWalletAddress)
     {
-        mockWallet = new ERC1271MaliciousMock(ownerAddress);
+        mockWallet = new ERC1271MaliciousMockForceRevert(ownerAddress);
         mockWalletAddress = address(mockWallet);
     }
 }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -212,7 +212,7 @@ contract ERC1271WalletMock is Ownable, IERC1271 {
     }
 }
 
-contract ERC1271MaliciousMock is Ownable, IERC1271 {
+contract ERC1271MaliciousMockForceRevert is Ownable, IERC1271 {
     constructor(address owner) {
         super.transferOwnership(owner);
     }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -10,7 +10,7 @@ import {StorageRegistry} from "../src/StorageRegistry.sol";
 import {Bundler} from "../src/Bundler.sol";
 import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
 import {IERC1271} from "openzeppelin/contracts/interfaces/IERC1271.sol";
-import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {SignatureChecker} from "openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 /* solhint-disable no-empty-blocks */
 
@@ -208,7 +208,8 @@ contract ERC1271WalletMock is Ownable, IERC1271 {
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4 magicValue) {
-        return ECDSA.recover(hash, signature) == owner() ? this.isValidSignature.selector : bytes4(0);
+        return
+            SignatureChecker.isValidSignatureNow(owner(), hash, signature) ? this.isValidSignature.selector : bytes4(0);
     }
 }
 

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -214,14 +214,25 @@ contract ERC1271WalletMock is Ownable, IERC1271 {
 }
 
 contract ERC1271MaliciousMockForceRevert is Ownable, IERC1271 {
+    bool internal _forceRevert = true;
+
     constructor(address owner) {
         super.transferOwnership(owner);
     }
 
-    function isValidSignature(bytes32, bytes memory) public pure returns (bytes4) {
-        assembly {
-            mstore(0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-            return(0, 32)
+    function setForceRevert(bool forceRevert) external {
+        _forceRevert = forceRevert;
+    }
+
+    function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4) {
+        if (_forceRevert) {
+            assembly {
+                mstore(0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                return(0, 32)
+            }
         }
+
+        return
+            SignatureChecker.isValidSignatureNow(owner(), hash, signature) ? this.isValidSignature.selector : bytes4(0);
     }
 }


### PR DESCRIPTION
## Motivation

Supporting smart contract wallets opens up malicious external contracts to try interfere with the forecaster contracts. The purpose of these tests is to make sure the positive and negative cases are handled correctly.


## Change Summary

Added the following mocks for testing

1. ERC1271WalletMock
2. ERC1271MaliciousMockError
3. ERC1271MaliciousMockInfiniteLoop

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR adds two mock smart contracts (`ERC1271WalletMock` and `ERC1271MaliciousMockForceRevert`) to the `Utils.sol` file.
- It also adds several test functions related to ERC1271 signature verification to the `IdRegistryTest.t.sol` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->