### PR TITLE
feat(StorageRegistry): treasurer should not be able to set price

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -144,7 +144,7 @@ StorageRent defines multiple roles rather than a single owner address.
 
 An `operator` role can credit storage to fids without the payment of rent. This is used for the initial migration to assign storage to existing users, so that their messages aren't auto-expired from Hubs.
 
-A `treasurer` role can move funds from the contract to a pre-defined `vault` address, but cannot change this destination. Only the `owner` may change the vault address to a new destination. The `treasurer` may also refresh the oracle price and set the storage unit price in USD.
+A `treasurer` role can move funds from the contract to a pre-defined `vault` address, but cannot change this destination. Only the `owner` may change the vault address to a new destination. The `treasurer` may also refresh the oracle price.
 
 An `owner` role can modify many parameters including the total supply of storage units, the price of rent, the duration for which exchange prices are valid and the deprecation timestamp.
 

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -678,8 +678,7 @@ contract StorageRegistry is AccessControlEnumerable {
      *
      * @param usdPrice The new unit price in USD. Fixed point value with 8 decimals.
      */
-    function setPrice(uint256 usdPrice) external {
-        if (!hasRole(OWNER_ROLE, msg.sender) && !hasRole(TREASURER_ROLE, msg.sender)) revert Unauthorized();
+    function setPrice(uint256 usdPrice) external onlyOwner {
         emit SetPrice(usdUnitPrice, usdPrice);
         usdUnitPrice = usdPrice;
     }

--- a/test/StorageRegistry/StorageRegistry.t.sol
+++ b/test/StorageRegistry/StorageRegistry.t.sol
@@ -1380,11 +1380,11 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
                            SET USD UNIT PRICE
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOnlyOwnerOrTreasurerCanSetUSDUnitPrice(address caller, uint256 unitPrice) public {
-        vm.assume(caller != owner && caller != treasurer);
+    function testFuzzOnlyOwnerCanSetUSDUnitPrice(address caller, uint256 unitPrice) public {
+        vm.assume(caller != owner);
 
         vm.prank(caller);
-        vm.expectRevert(StorageRegistry.Unauthorized.selector);
+        vm.expectRevert(StorageRegistry.NotOwner.selector);
         storageRegistry.setPrice(unitPrice);
     }
 


### PR DESCRIPTION
## Motivation

The treasurer role has the ability to set the storage price which is a dangerous action since it can eliminate signup costs and make it easy for spammers to join the network. This change restricts that ability to just the owner account.  

## Change Summary

- Don't allow treasurer role to set the storage price

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.
