### PR TITLE
chore: add signing commits to PR guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ _Choose all relevant options below by adding an `x` now or at any time before su
 - [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
 - [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
 - [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
-- [ ] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)
+- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)
 
 ## Additional Context
 


### PR DESCRIPTION
## Motivation

Add a link to signing commits to make it easier for new contributors to discover this security requirement and get it configured.

## Change Summary

- Added a requirement to sign commits
- Removed the requirement to check box about changes to protocol, since it was never used

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] This PR does not require changes to the [Farcaster protocol](https://github.com/farcasterxyz/protocol)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a requirement for all commits to be signed. 

### Detailed summary
- Added a new checkbox for all commits to be signed
- Updated the contribution guidelines to include information on signing commits

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->