### PR TITLE
chore: use fcast.id domain

### DIFF
--- a/test/FnameResolver/FnameResolverTestSuite.sol
+++ b/test/FnameResolver/FnameResolverTestSuite.sol
@@ -11,27 +11,26 @@ import {FnameResolverHarness} from "../Utils.sol";
 abstract contract FnameResolverTestSuite is TestSuiteSetup {
     FnameResolverHarness internal resolver;
 
-    string internal constant FNAME_SERVER_URL = "https://fnames.farcaster.xyz/ccip/{sender}/{data}.json";
+    string internal constant FNAME_SERVER_URL = "https://fnames.fcast.id/ccip/{sender}/{data}.json";
 
     /**
-     * @dev DNS-encoding of "alice.farcaster.xyz". The DNS-encoded name consists of:
+     * @dev DNS-encoding of "alice.fcast.id". The DNS-encoded name consists of:
      *      - 1 byte for the length of the first label (5)
      *      - 5 bytes for the label ("alice")
-     *      - 1 byte for the length of the second label (9)
-     *      - 9 bytes for the label ("farcaster")
-     *      - 1 byte for the length of the third label (3)
-     *      - 3 bytes for the label ("xyz")
+     *      - 1 byte for the length of the second label (5)
+     *      - 5 bytes for the label ("fcast")
+     *      - 1 byte for the length of the third label (2)
+     *      - 2 bytes for the label ("id")
      *      - A null byte terminating the encoded name.
      */
     bytes internal constant DNS_ENCODED_NAME =
-        (hex"05" hex"616c696365" hex"09" hex"666172636173746572" hex"03" hex"78797a" hex"00");
+        (hex"05" hex"616c696365" hex"05" hex"6663617374" hex"02" hex"6964" hex"00");
 
     /**
      * @dev Encoded calldata for a call to addr(bytes32 node), where node is the ENS
-     *      nameHash encoded value of "alice.farcaster.xyz"
+     *      nameHash encoded value of "alice.fcast.id"
      */
-    bytes internal constant ADDR_QUERY_CALLDATA =
-        hex"3b3b57de00d4f449060ad2a07ff5ad355ae8da52281e95f6ad10fb923ae7cad9f2c43c2a";
+    bytes internal constant ADDR_QUERY_CALLDATA = hex"c30dc5a16498c5b6d46f97ca0c74d092ebbee1290b1c88f6e435dd4fb306ca36";
 
     address internal signer;
     uint256 internal signerPk;


### PR DESCRIPTION
## Motivation

Update the fname resolver tests to use the real fname domain, `fcast.id`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the FnameResolverTestSuite.sol file by changing the FNAME_SERVER_URL constant and DNS_ENCODED_NAME constant to use the new domain "fcast.id" instead of "farcaster.xyz".

### Detailed summary:
- Changed the FNAME_SERVER_URL constant from "https://fnames.farcaster.xyz/ccip/{sender}/{data}.json" to "https://fnames.fcast.id/ccip/{sender}/{data}.json".
- Updated the DNS_ENCODED_NAME constant to reflect the new domain "alice.fcast.id" instead of "alice.farcaster.xyz".
- Modified the ADDR_QUERY_CALLDATA constant to use the nameHash encoded value of "alice.fcast.id" instead of "alice.farcaster.xyz".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->