### PR TITLE
chore: remove rental period constructor arg

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -8,7 +8,6 @@ import {Bundler} from "../src/Bundler.sol";
 import {ImmutableCreate2Deployer} from "./lib/ImmutableCreate2Deployer.sol";
 
 contract Deploy is ImmutableCreate2Deployer {
-    uint256 public constant INITIAL_RENTAL_PERIOD = 365 days;
     uint256 public constant INITIAL_USD_UNIT_PRICE = 5e8; // $5 USD
     uint256 public constant INITIAL_MAX_UNITS = 2_000_000;
     uint256 public constant INITIAL_PRICE_FEED_CACHE_DURATION = 1 days;
@@ -54,7 +53,6 @@ contract Deploy is ImmutableCreate2Deployer {
             abi.encode(
                 params.priceFeed,
                 params.uptimeFeed,
-                INITIAL_RENTAL_PERIOD,
                 INITIAL_USD_UNIT_PRICE,
                 INITIAL_MAX_UNITS,
                 params.vault,

--- a/script/LocalDeploy.s.sol
+++ b/script/LocalDeploy.s.sol
@@ -46,7 +46,6 @@ contract LocalDeploy is Script {
         StorageRegistry storageRegistry = new StorageRegistry{ salt: STORAGE_RENT_CREATE2_SALT }(
             priceFeed,
             uptimeFeed,
-            INITIAL_RENTAL_PERIOD,
             INITIAL_USD_UNIT_PRICE,
             INITIAL_MAX_UNITS,
             vault,

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -321,7 +321,6 @@ contract StorageRegistry is AccessControlEnumerable {
      *
      * @param _priceFeed                     Chainlink ETH/USD price feed.
      * @param _uptimeFeed                    Chainlink L2 sequencer uptime feed.
-     * @param _initialDeprecationPeriod      Initial deprecation period in seconds.
      * @param _initialUsdUnitPrice           Initial unit price in USD. Fixed point 8 decimal value.
      * @param _initialMaxUnits               Initial maximum capacity in storage units.
      * @param _initialVault                  Initial vault address.
@@ -333,7 +332,6 @@ contract StorageRegistry is AccessControlEnumerable {
     constructor(
         AggregatorV3Interface _priceFeed,
         AggregatorV3Interface _uptimeFeed,
-        uint256 _initialDeprecationPeriod,
         uint256 _initialUsdUnitPrice,
         uint256 _initialMaxUnits,
         address _initialVault,
@@ -345,7 +343,7 @@ contract StorageRegistry is AccessControlEnumerable {
         priceFeed = _priceFeed;
         uptimeFeed = _uptimeFeed;
 
-        deprecationTimestamp = block.timestamp + _initialDeprecationPeriod;
+        deprecationTimestamp = block.timestamp + 365 days;
         emit SetDeprecationTimestamp(0, deprecationTimestamp);
 
         usdUnitPrice = _initialUsdUnitPrice;

--- a/test/Deploy/Deploy.t.sol
+++ b/test/Deploy/Deploy.t.sol
@@ -74,7 +74,7 @@ contract DeployTest is Test {
     function test_deploymentParams() public {
         assertEq(address(storageRegistry.priceFeed()), priceFeed);
         assertEq(address(storageRegistry.uptimeFeed()), uptimeFeed);
-        assertEq(storageRegistry.deprecationTimestamp(), block.timestamp + deploy.INITIAL_RENTAL_PERIOD());
+        assertEq(storageRegistry.deprecationTimestamp(), block.timestamp + 365 days);
         assertEq(storageRegistry.usdUnitPrice(), deploy.INITIAL_USD_UNIT_PRICE());
         assertEq(storageRegistry.maxUnits(), deploy.INITIAL_MAX_UNITS());
         assertEq(storageRegistry.priceFeedCacheDuration(), deploy.INITIAL_PRICE_FEED_CACHE_DURATION());

--- a/test/StorageRegistry/StorageRegistryTestSuite.sol
+++ b/test/StorageRegistry/StorageRegistryTestSuite.sol
@@ -71,7 +71,6 @@ abstract contract StorageRegistryTestSuite is TestSuiteSetup {
         storageRegistry = new StorageRegistryHarness(
             priceFeed,
             uptimeFeed,
-            INITIAL_RENTAL_PERIOD,
             INITIAL_USD_UNIT_PRICE,
             INITIAL_MAX_UNITS,
             vault,

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -92,7 +92,6 @@ contract StorageRegistryHarness is StorageRegistry {
     constructor(
         AggregatorV3Interface _priceFeed,
         AggregatorV3Interface _uptimeFeed,
-        uint256 _rentalPeriod,
         uint256 _usdUnitPrice,
         uint256 _maxUnits,
         address _vault,
@@ -104,7 +103,6 @@ contract StorageRegistryHarness is StorageRegistry {
         StorageRegistry(
             _priceFeed,
             _uptimeFeed,
-            _rentalPeriod,
             _usdUnitPrice,
             _maxUnits,
             _vault,


### PR DESCRIPTION
## Motivation

We don't need to configure the rental period at construction time, so we can hardcode it.

## Change Summary

Hardcode rental period to `365 days`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on removing the `INITIAL_RENTAL_PERIOD` parameter and related code from the `StorageRegistry` contract and its dependencies.

### Detailed summary:
- Remove `INITIAL_RENTAL_PERIOD` parameter and related code from `StorageRegistry` contract and its dependencies.
- Update tests and assertions to reflect the removal of `INITIAL_RENTAL_PERIOD` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->