### PR TITLE
chore: Add Docker Compose file for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.9'
+
+services:
+  anvil:
+    image: ghcr.io/foundry-rs/foundry:v1.0.0
+    entrypoint: ""
+    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state']
+    environment:
+      - MAINNET_RPC_URL
+    volumes:
+      - anvil-data:/var/lib/anvil
+    ports:
+      - '${PORT:-8545}:${PORT:-8545}'
+    restart: on-failure
+    healthcheck:
+      test: ['CMD', '/usr/bin/nc', '-z', 'localhost', '${PORT:-8545}']
+      interval: 1s
+      timeout: 1s
+      retries: 3
+
+  deployer:
+    image: ghcr.io/foundry-rs/foundry:v1.0.0
+    depends_on:
+      - anvil
+    environment:
+      - DEPLOYER
+    volumes:
+      - .:/app
+    working_dir: /app
+    entrypoint: |
+      sh -c '
+        set -e
+        export RPC_URL="http://anvil:${PORT:-8545}"
+        echo "Waiting for Anvil..."
+        while ! nc -z anvil "${PORT:-8545}"; do sleep 0.1; done
+        echo "Anvil online"
+        echo "Enabling impersonation"
+        cast rpc anvil_autoImpersonateAccount true --rpc-url "$$RPC_URL"
+        echo "Deploying contract"
+        forge script -v script/Deploy.s.sol --rpc-url "$$RPC_URL" --unlocked --broadcast --sender "$$DEPLOYER"
+        echo "Disabling impersonation"
+        cast rpc anvil_autoImpersonateAccount false --rpc-url "$$RPC_URL"
+        echo "Deploy complete"
+      '
+
+volumes:
+  anvil-data:


### PR DESCRIPTION
## Motivation

This sets up a Docker Compose configuration so that you can simply run `docker compose up` and have a running Anvil instance with the contract automatically deployed to it.

This makes development easier to get started.

## Change Summary


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding services to the `docker-compose.yml` file and configuring their settings. 

### Detailed summary
- Added a new service called `anvil` with its image and entrypoint.
- Configured the command for the `anvil` service, including host, port, RPC URL, and state.
- Defined environment variables for the `anvil` service.
- Specified volumes and ports for the `anvil` service.
- Set restart and healthcheck configurations for the `anvil` service.
- Added a new service called `deployer` with its image and dependencies.
- Configured environment variables and volumes for the `deployer` service.
- Set the working directory and entrypoint for the `deployer` service.
- Added a script to wait for the `anvil` service to be available and perform deployment tasks.
- Created a volume called `anvil-data`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->