### PR TITLE
fix: Switch deployer Docker Compose service to use nightly image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   deployer:
-    image: ghcr.io/foundry-rs/foundry:v1.0.0
+    image: ghcr.io/foundry-rs/foundry:nightly
     depends_on:
       - anvil
     environment:


### PR DESCRIPTION
## Motivation

We seem to non-deterministically hit OOM errors when using v1.0.0 when deploying the contract, so switch to `nightly` to avoid.

## Change Summary


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `deployer` image in the `docker-compose.yml` file from version `v1.0.0` to `nightly`.

### Detailed summary:
- Updated `deployer` image from `v1.0.0` to `nightly` in `docker-compose.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->