### PR TITLE
chore: add network to Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 3
+    networks:
+      - contracts_subnet
 
   deployer:
     image: ghcr.io/foundry-rs/foundry:nightly
@@ -42,6 +44,13 @@ services:
         cast rpc anvil_autoImpersonateAccount false --rpc-url "$$RPC_URL"
         echo "Deploy complete"
       '
+    networks:
+      - contracts_subnet
 
 volumes:
   anvil-data:
+
+networks:
+  # Allows us to share the services in this file with other Docker Compose files
+  contracts_subnet:
+    driver: bridge


### PR DESCRIPTION
## Motivation

This allows us to share these services with other Docker Compose files, by specifying the subnet to add explicitly.

## Change Summary

Add the network declaration.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `contracts_subnet` network to the `docker-compose.yml` file
- Added `contracts_subnet` network to the `deployer` service's networks
- Added `contracts_subnet` network to the `anvil-data` volume's networks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->