### PR TITLE
chore: Use custom Docker image for local development

### DIFF
--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.4
+
+# Used for local development so that we have binaries compiled for the local
+# architecture, since Foundry only publishes Docker images for AMD, and we don't
+# want to have slow emulation on Apple Silicon.
+
+FROM ubuntu:latest
+
+RUN apt-get update -y && apt-get install -y curl bash git netcat
+RUN curl -L https://foundry.paradigm.xyz | bash
+ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
+RUN foundryup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,11 @@ version: '3.9'
 
 services:
   anvil:
-    image: ghcr.io/foundry-rs/foundry:v1.0.0
+    build:
+      dockerfile: Dockerfile.foundry
+      context: .
     entrypoint: ""
-    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state']
+    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--block-time', '2', '--retries', '3', '--timeout', '10000']
     environment:
       - MAINNET_RPC_URL
     volumes:
@@ -21,7 +23,9 @@ services:
       - contracts_subnet
 
   deployer:
-    image: ghcr.io/foundry-rs/foundry:nightly
+    build:
+      dockerfile: Dockerfile.foundry
+      context: .
     depends_on:
       - anvil
     environment:


### PR DESCRIPTION
## Motivation

We're seeing issues where it appears qemu fails causing issues for the image provided by Foundry (which at time of writing is AMD only).

So that we don't need emulation, build image on the fly specific to the local system.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)
