### PR TITLE
chore: Improve local dev experience on restart of Anvil container

### DIFF
--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -9,4 +9,6 @@ FROM ubuntu:latest
 RUN apt-get update -y && apt-get install -y curl bash git netcat
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
-RUN foundryup
+
+# Use a stable commit so that we don't have surprising breakages when rebuilding
+RUN foundryup --commit d4f626bb7f96d46358997d4b27f79358cb2b3401 # August 8, 2023

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
       dockerfile: Dockerfile.foundry
       context: .
     entrypoint: ""
-    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--block-time', '2', '--retries', '3', '--timeout', '10000']
+    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--retries', '3', '--timeout', '10000']
     environment:
       - MAINNET_RPC_URL
     volumes:
       - anvil-data:/var/lib/anvil
+      - anvil-cache:/root/.foundry/cache
     ports:
       - '${PORT:-8545}:${PORT:-8545}'
     restart: on-failure
@@ -52,6 +53,7 @@ services:
       - contracts_subnet
 
 volumes:
+  anvil-cache:
   anvil-data:
 
 networks:


### PR DESCRIPTION
## Motivation

We weren't preserving the `cache` directory (which wasn't documented).

We also hard code the commit we pull so that it's stable.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the Dockerfile and docker-compose.yml to use a stable commit of `foundryup` and add a new volume for `anvil-cache`.

### Detailed summary:
- Dockerfile.foundry:
  - Updated the `foundryup` command to use a stable commit of `foundryup` (`d4f626bb7f96d46358997d4b27f79358cb2b3401`).
- docker-compose.yml:
  - Added a new volume `anvil-cache` for `/root/.foundry/cache`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->