### PR TITLE
fix: Install specific nightly release

### DIFF
--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -8,7 +8,10 @@ FROM ubuntu:latest
 
 RUN apt-get update -y && apt-get install -y curl bash git netcat
 RUN curl -L https://foundry.paradigm.xyz | bash
+
 ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
 
-# Use a stable commit so that we don't have surprising breakages when rebuilding
-RUN foundryup --commit d4f626bb7f96d46358997d4b27f79358cb2b3401 # August 8, 2023
+# Hardcode release so that we don't have surprising breakages when rebuilding by
+# automatically downloading the latest release every time.
+# https://github.com/foundry-rs/foundry/releases/tag/nightly-d4f626bb7f96d46358997d4b27f79358cb2b3401
+RUN foundryup --version nightly-d4f626bb7f96d46358997d4b27f79358cb2b3401


### PR DESCRIPTION

## Motivation

This doesn't require us to install the whole Rust ecosystem to build.


## Merge Checklist

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Dockerfile to hardcode the release version of Foundry instead of using a stable commit. 

### Detailed summary
- Changed the RUN command to download the latest release version of Foundry instead of a specific commit.
- Updated the comment to reflect the change in approach.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->