### PR TITLE
bug(IdRegistry): fix transfer typehash

### DIFF
--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -131,7 +131,9 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
      *             other resolver function will revert.
      */
     function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory) {
-        if (bytes4(data[:4]) != IAddressQuery.addr.selector) revert ResolverFunctionNotSupported();
+        if (bytes4(data[:4]) != IAddressQuery.addr.selector) {
+            revert ResolverFunctionNotSupported();
+        }
 
         bytes memory callData = abi.encodeCall(IResolverService.resolve, (name, data));
         string[] memory urls = new string[](1);
@@ -160,7 +162,7 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
             abi.decode(response, (string, uint256, address, bytes));
 
         bytes32 proofHash =
-            keccak256(abi.encode(_USERNAME_PROOF_TYPEHASH, keccak256(abi.encodePacked(fname)), timestamp, fnameOwner));
+            keccak256(abi.encode(_USERNAME_PROOF_TYPEHASH, keccak256(bytes(fname)), timestamp, fnameOwner));
         bytes32 eip712hash = _hashTypedDataV4(proofHash);
         address signer = ECDSA.recover(eip712hash, signature);
 

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -84,7 +84,7 @@ contract IdRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
         keccak256("Register(address to,address recovery,uint256 nonce,uint256 deadline)");
 
     bytes32 internal constant _TRANSFER_TYPEHASH =
-        keccak256("Transfer(address from,address to,uint256 nonce,uint256 deadline)");
+        keccak256("Transfer(uint256 fid,address to,uint256 nonce,uint256 deadline)");
 
     /*//////////////////////////////////////////////////////////////
                                  STORAGE

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -373,7 +373,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
         bytes[][] calldata fidKeys,
         bytes calldata metadata
     ) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and
@@ -399,7 +401,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      * @param fidKeys A list of keys to remove for each fid, in the same order as the fids array.
      */
     function bulkResetKeysForMigration(uint256[] calldata fids, bytes[][] calldata fidKeys) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -115,6 +115,12 @@ contract FnameResolverTest is FnameResolverTestSuite {
         resolver.resolveWithProof(abi.encode(name, timestamp, owner, signature), "");
     }
 
+    function testProofTypehash() public {
+        assertEq(
+            resolver.usernameProofTypehash(), keccak256("UserNameProof(string name,uint256 timestamp,address owner)")
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////
                                  SIGNERS
     //////////////////////////////////////////////////////////////*/
@@ -196,7 +202,7 @@ contract FnameResolverTest is FnameResolverTestSuite {
         address owner
     ) internal returns (bytes memory signature) {
         bytes32 eip712hash = resolver.hashTypedDataV4(
-            keccak256(abi.encode(resolver.usernameProofTypehash(), keccak256(abi.encodePacked(name)), timestamp, owner))
+            keccak256(abi.encode(resolver.usernameProofTypehash(), keccak256(bytes(name)), timestamp, owner))
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, eip712hash);
         signature = abi.encodePacked(r, s, v);

--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -302,6 +302,13 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.getRecoveryOf(1), address(0));
     }
 
+    function testRegisterTypehash() public {
+        assertEq(
+            idRegistry.registerTypehash(),
+            keccak256("Register(address to,address recovery,uint256 nonce,uint256 deadline)")
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////
                          TRUSTED REGISTER TESTS
     //////////////////////////////////////////////////////////////*/
@@ -622,6 +629,12 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.getIdCounter(), 2);
         assertEq(idRegistry.idOf(from), 2);
         assertEq(idRegistry.idOf(to), 1);
+    }
+
+    function testTransferTypehash() public {
+        assertEq(
+            idRegistry.transferTypehash(), keccak256("Transfer(uint256 fid,address to,uint256 nonce,uint256 deadline)")
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/KeyRegistry/KeyRegistry.t.sol
+++ b/test/KeyRegistry/KeyRegistry.t.sol
@@ -311,6 +311,13 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertNull(fid, key);
     }
 
+    function testAddTypeHash() public {
+        assertEq(
+            keyRegistry.addTypehash(),
+            keccak256("Add(address owner,uint32 scheme,bytes key,bytes metadata,uint256 nonce,uint256 deadline)")
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////
                                  REMOVE
     //////////////////////////////////////////////////////////////*/
@@ -522,6 +529,12 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.removeFor(owner, key, deadline, sig);
 
         assertAdded(fid, key, scheme);
+    }
+
+    function testRemoveTypeHash() public {
+        assertEq(
+            keyRegistry.removeTypehash(), keccak256("Remove(address owner,bytes key,uint256 nonce,uint256 deadline)")
+        );
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

Fix an error in `IdRegistry._TRANSFER_TYPEHASH` See #329 for details.

## Change Summary

Update `IdRegistry._TRANSFER_TYPEHASH` to the correct value. Double check other typehashes. Add typehash-specific test cases: this slipped past the property tests because we were reading the typehash value from the contract under test.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #329 


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated the `TRANSFER_TYPEHASH` constant in `IdRegistry.sol` to include a new parameter.
- Added a new test function `testAddTypeHash` in `KeyRegistryTest` to test the `addTypehash` function.
- Added a new test function `testRemoveTypeHash` in `KeyRegistryTest` to test the `removeTypehash` function.
- Added a new test function `testRegisterTypehash` in `IdRegistryTest` to test the `registerTypehash` function.
- Added a new test function `testTransferTypehash` in `IdRegistryTest` to test the `transferTypehash` function.
- Added a new test function `testProofTypehash` in `FnameResolverTest` to test the `usernameProofTypehash` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->