### PR TITLE
fix(Bundler): revert on direct ether transfers

### DIFF
--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -171,5 +171,7 @@ contract Bundler is TrustedCaller {
     }
 
     // solhint-disable-next-line no-empty-blocks
-    receive() external payable {}
+    receive() external payable {
+        if (msg.sender != address(storageRegistry)) revert Unauthorized();
+    }
 }

--- a/test/Bundler/Bundler.t.sol
+++ b/test/Bundler/Bundler.t.sol
@@ -53,7 +53,9 @@ contract BundlerTest is BundlerTestSuite {
         uint256 deadline,
         uint256 numSigners
     ) internal returns (Bundler.SignerParams[] memory) {
-        Bundler.SignerParams[] memory signers = new Bundler.SignerParams[](numSigners);
+        Bundler.SignerParams[] memory signers = new Bundler.SignerParams[](
+            numSigners
+        );
         uint256 nonce = keyRegistry.nonces(account);
 
         // The duplication below is ugly but necessary to work around a stack too deep error.
@@ -294,7 +296,9 @@ contract BundlerTest is BundlerTestSuite {
         vm.prank(roleAdmin);
         storageRegistry.grantRole(operatorRoleId, address(bundler));
 
-        Bundler.UserData[] memory batchArray = new Bundler.UserData[](registrations);
+        Bundler.UserData[] memory batchArray = new Bundler.UserData[](
+            registrations
+        );
 
         for (uint256 i = 0; i < registrations; i++) {
             uint160 fid = uint160(i + 1);
@@ -513,5 +517,18 @@ contract BundlerTest is BundlerTestSuite {
 
         assertEq(bundler.owner(), owner);
         assertEq(bundler.pendingOwner(), newOwner);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             RECEIVE 
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzzRevertsDirectPayments(address sender, uint256 amount) public {
+        vm.assume(sender != address(storageRegistry));
+
+        deal(sender, amount);
+        vm.prank(sender);
+        vm.expectRevert(Bundler.Unauthorized.selector);
+        payable(address(bundler)).transfer(amount);
     }
 }


### PR DESCRIPTION
## Motivation

Since the `Bundler` exposes a payable `receive()` function, it's possible to accidentally send it ether directly, which would then be locked in the contract. See #330.

## Change Summary

Revert in `receive()` if `msg.sender` is not the `StorageRegistry`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #330.