### PR TITLE
fix(StorageRegistry): check that fixed price is in bounds

### DIFF
--- a/test/StorageRegistry/StorageRegistry.t.sol
+++ b/test/StorageRegistry/StorageRegistry.t.sol
@@ -311,7 +311,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         newEthUsdPrice = bound(
             newEthUsdPrice, int256(storageRegistry.priceFeedMinAnswer()), int256(storageRegistry.priceFeedMaxAnswer())
         );
-        fixedPrice = bound(fixedPrice, 10e8, 100_000e8);
+        fixedPrice = bound(fixedPrice, 100e8, 10_000e8);
 
         _rentStorage(msgSender1, id1, units1);
 
@@ -867,7 +867,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         vm.prank(owner);
         storageRegistry.setPrice(usdUnitPrice);
 
-        assertEq(storageRegistry.unitPrice(), uint256(usdUnitPrice) * 1e18 / cachedPrice);
+        assertEq(storageRegistry.unitPrice(), (uint256(usdUnitPrice) * 1e18) / cachedPrice);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1421,6 +1421,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
     }
 
     function testFuzzSetFixedEthUsdPrice(uint256 fixedPrice) public {
+        fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         assertEq(storageRegistry.fixedEthUsdPrice(), 0);
 
         vm.expectEmit(false, false, false, true);
@@ -1433,6 +1434,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
     }
 
     function testFuzzSetFixedEthUsdPriceOverridesPriceFeed(uint256 fixedPrice) public {
+        fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         vm.assume(fixedPrice != storageRegistry.ethUsdPrice());
         fixedPrice = bound(fixedPrice, 1, type(uint256).max);
 
@@ -1449,6 +1451,7 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
     }
 
     function testFuzzRemoveFixedEthUsdPriceReenablesPriceFeed(uint256 fixedPrice) public {
+        fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         vm.assume(fixedPrice != storageRegistry.ethUsdPrice());
         fixedPrice = bound(fixedPrice, 1, type(uint256).max);
 


### PR DESCRIPTION
## Motivation

It's possible for the `StorageRegistry` owner to set a `fixedEthUsdPrice` that is outside the `priceFeedMinAnswer`/`priceFeedMaxAnswer` bounds. See #331.

## Change Summary

Check `fixedEthUsdPrice` in `setFixedethUsdPrice` and revert if it's nonzero and outside the configured bounds.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #331.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `InvalidFixedPrice` error to revert if the `fixedEthUsdPrice` is outside the configured price bounds.
- Added check for `InvalidFixedPrice` error in the `setFixedEthUsdPrice` function.
- Added curly braces for better code readability in the `whenNotDeprecated` and `block.timestamp - priceUpdatedAt > priceFeedMaxAge` conditions.
- Updated the bounds for `fixedPrice` in the `StorageRegistry.t.sol` test file.
- Added bounds check for `fixedPrice` in the `testFuzzSetFixedEthUsdPrice`, `testFuzzSetFixedEthUsdPriceOverridesPriceFeed`, and `testFuzzRemoveFixedEthUsdPriceReenablesPriceFeed` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->