### PR TITLE
fix(KeyRegistry): set fixed gracePeriod

### DIFF
--- a/script/LocalDeploy.s.sol
+++ b/script/LocalDeploy.s.sol
@@ -17,8 +17,6 @@ contract LocalDeploy is Script {
     uint256 internal constant INITIAL_PRICE_FEED_CACHE_DURATION = 1 days;
     uint256 internal constant INITIAL_UPTIME_FEED_GRACE_PERIOD = 1 hours;
 
-    uint24 internal constant KEY_REGISTRY_MIGRATION_GRACE_PERIOD = 1 days;
-
     bytes32 internal constant ID_REGISTRY_CREATE2_SALT = "fc";
     bytes32 internal constant KEY_REGISTRY_CREATE2_SALT = "fc";
     bytes32 internal constant STORAGE_RENT_CREATE2_SALT = "fc";
@@ -37,13 +35,15 @@ contract LocalDeploy is Script {
 
         vm.startBroadcast();
         (AggregatorV3Interface priceFeed, AggregatorV3Interface uptimeFeed) = _getOrDeployPriceFeeds();
-        IdRegistry idRegistry = new IdRegistry{ salt: ID_REGISTRY_CREATE2_SALT }(initialIdRegistryOwner);
-        KeyRegistry keyRegistry = new KeyRegistry{ salt: KEY_REGISTRY_CREATE2_SALT }(
-            address(idRegistry),
-            KEY_REGISTRY_MIGRATION_GRACE_PERIOD,
-            initialKeyRegistryOwner
+        IdRegistry idRegistry = new IdRegistry{salt: ID_REGISTRY_CREATE2_SALT}(
+            initialIdRegistryOwner
         );
-        StorageRegistry storageRegistry = new StorageRegistry{ salt: STORAGE_RENT_CREATE2_SALT }(
+        KeyRegistry keyRegistry = new KeyRegistry{
+            salt: KEY_REGISTRY_CREATE2_SALT
+        }(address(idRegistry), initialKeyRegistryOwner);
+        StorageRegistry storageRegistry = new StorageRegistry{
+            salt: STORAGE_RENT_CREATE2_SALT
+        }(
             priceFeed,
             uptimeFeed,
             INITIAL_USD_UNIT_PRICE,
@@ -94,8 +94,8 @@ contract LocalDeploy is Script {
         returns (AggregatorV3Interface priceFeed, AggregatorV3Interface uptimeFeed)
     {
         if (block.chainid == 31337) {
-            MockPriceFeed _priceFeed = new MockPriceFeed{ salt: bytes32(0) }();
-            MockUptimeFeed _uptimeFeed = new MockUptimeFeed{ salt: bytes32(0) }();
+            MockPriceFeed _priceFeed = new MockPriceFeed{salt: bytes32(0)}();
+            MockUptimeFeed _uptimeFeed = new MockUptimeFeed{salt: bytes32(0)}();
             _priceFeed.setRoundData(
                 MockChainlinkFeed.RoundData({
                     roundId: 1,

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -171,7 +171,7 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
         keccak256("Remove(address owner,bytes key,uint256 nonce,uint256 deadline)");
 
     /*//////////////////////////////////////////////////////////////
-                                IMMUTABLES
+                                CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
     /**
@@ -179,7 +179,7 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      *      Admins can make corrections to the migrated data during the grace period if necessary,
      *      but cannot make changes after it expires.
      */
-    uint24 public immutable gracePeriod;
+    uint24 public constant gracePeriod = uint24(24 hours);
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -214,15 +214,12 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      * @notice Set the IdRegistry, migration grace period, and owner.
      *
      * @param _idRegistry   IdRegistry contract address.
-     * @param _gracePeriod  Migration grace period in seconds. Immutable.
      * @param _initialOwner Initial contract owner address.
      */
     constructor(
         address _idRegistry,
-        uint24 _gracePeriod,
         address _initialOwner
     ) TrustedCaller(_initialOwner) EIP712("Farcaster KeyRegistry", "1") {
-        gracePeriod = _gracePeriod;
         idRegistry = IdRegistryLike(_idRegistry);
     }
 
@@ -373,7 +370,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
         bytes[][] calldata fidKeys,
         bytes calldata metadata
     ) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and
@@ -399,7 +398,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      * @param fidKeys A list of keys to remove for each fid, in the same order as the fids array.
      */
     function bulkResetKeysForMigration(uint256[] calldata fids, bytes[][] calldata fidKeys) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and

--- a/test/KeyRegistry/KeyRegistryTestSuite.sol
+++ b/test/KeyRegistry/KeyRegistryTestSuite.sol
@@ -14,7 +14,7 @@ abstract contract KeyRegistryTestSuite is IdRegistryTestSuite {
     function setUp() public virtual override {
         super.setUp();
 
-        keyRegistry = new KeyRegistryHarness(address(idRegistry), 1 days, owner);
+        keyRegistry = new KeyRegistryHarness(address(idRegistry), owner);
     }
 
     function _signAdd(

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -69,11 +69,7 @@ contract IdRegistryHarness is IdRegistry {
 }
 
 contract KeyRegistryHarness is KeyRegistry {
-    constructor(
-        address _idRegistry,
-        uint24 _gracePeriod,
-        address _owner
-    ) KeyRegistry(_idRegistry, _gracePeriod, _owner) {}
+    constructor(address _idRegistry, address _owner) KeyRegistry(_idRegistry, _owner) {}
 
     function hashTypedDataV4(bytes32 structHash) public view returns (bytes32) {
         return _hashTypedDataV4(structHash);


### PR DESCRIPTION
## Motivation

The deployer can set an arbitrary `KeyRegistry.gracePeriod`, but we'd like to constrain this by hardcoding a fixed value. See #332.

## Change Summary

Convert `gracePeriod` to a constant and remove this parameter from the `KeyRegistry` constructor.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #332 