### PR TITLE
feat(Bundler): revert on register with zero storage units

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,4 +1,4 @@
-BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 827208)
+BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 827415)
 BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 6639777)
 BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 851686)
 IdRegistryGasUsageTest:testGasRegister() (gas: 735214)

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -17,6 +17,9 @@ contract Bundler is TrustedCaller {
     /// @dev Revert if the caller does not have the authority to perform the action.
     error Unauthorized();
 
+    /// @dev Revert if the caller attempts to rent zero storage units.
+    error InvalidAmount();
+
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -106,6 +109,7 @@ contract Bundler is TrustedCaller {
         SignerParams[] calldata signers,
         uint256 storageUnits
     ) external payable {
+        if (storageUnits == 0) revert InvalidAmount();
         uint256 fid =
             idRegistry.registerFor(registration.to, registration.recovery, registration.deadline, registration.sig);
 


### PR DESCRIPTION
## Motivation

The `StorageRegistry` reverts purchases of zero storage units. We should check for this and revert early in the `Bundler`.

## Change Summary

Revert early in `Bundler.register` if caller attempts to rent zero `storageUnits`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #333


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to add a check to revert the transaction if the caller attempts to rent zero storage units.
- An `InvalidAmount` error is added to handle this case.
- The `register` function in the `Bundler` contract is updated to include this check.
- A new test function `testFuzzRegisterRevertsZeroUnits` is added to test the revert behavior when zero storage units are passed.
- Minor formatting changes are made in the `Bundler` contract and the test file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->