### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {Nonces} from "openzeppelin-latest/contracts/utils/Nonces.sol";
 
@@ -373,7 +372,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
         bytes[][] calldata fidKeys,
         bytes calldata metadata
     ) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and
@@ -399,7 +400,9 @@ contract KeyRegistry is TrustedCaller, Signatures, EIP712, Nonces {
      * @param fidKeys A list of keys to remove for each fid, in the same order as the fids array.
      */
     function bulkResetKeysForMigration(uint256[] calldata fids, bytes[][] calldata fidKeys) external onlyOwner {
-        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) revert Unauthorized();
+        if (isMigrated() && block.timestamp > keysMigratedAt + gracePeriod) {
+            revert Unauthorized();
+        }
         if (fids.length != fidKeys.length) revert InvalidBatchInput();
 
         // Safety: i and j can be incremented unchecked since they are bound by fids.length and

--- a/src/lib/TrustedCaller.sol
+++ b/src/lib/TrustedCaller.sol
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import {ECDSA} from "openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {EIP712} from "openzeppelin/contracts/utils/cryptography/EIP712.sol";
-import {Nonces} from "openzeppelin-latest/contracts/utils/Nonces.sol";
 import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
-import {Pausable} from "openzeppelin/contracts/security/Pausable.sol";
 
 abstract contract TrustedCaller is Ownable2Step {
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

Remove a few unused imports.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Close #336

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The imports of `ECDSA`, `EIP712`, and `Nonces` from the `openzeppelin` library have been removed in `TrustedCaller.sol`.
- The import of `ECDSA` from the `openzeppelin` library has been removed in `KeyRegistry.sol`.
- The code has been updated to use the `revert Unauthorized()` syntax instead of `revert Unauthorized` in `KeyRegistry.sol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->