### PR TITLE
chore: add tests for InvalidFixedPrice

### DIFF
--- a/test/StorageRegistry/StorageRegistry.t.sol
+++ b/test/StorageRegistry/StorageRegistry.t.sol
@@ -1443,6 +1443,24 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.fixedEthUsdPrice(), fixedPrice);
     }
 
+    function testFuzzSetFixedEthUsdPriceRevertsLessThanMinPrice(uint256 fixedPrice) public {
+        fixedPrice = bound(fixedPrice, 1, storageRegistry.priceFeedMinAnswer() - 1);
+        assertEq(storageRegistry.fixedEthUsdPrice(), 0);
+
+        vm.prank(owner);
+        vm.expectRevert(StorageRegistry.InvalidFixedPrice.selector);
+        storageRegistry.setFixedEthUsdPrice(fixedPrice);
+    }
+
+    function testFuzzSetFixedEthUsdPriceRevertsGreaterThanMaxPrice(uint256 fixedPrice) public {
+        fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMaxAnswer() + 1, type(uint256).max);
+        assertEq(storageRegistry.fixedEthUsdPrice(), 0);
+
+        vm.prank(owner);
+        vm.expectRevert(StorageRegistry.InvalidFixedPrice.selector);
+        storageRegistry.setFixedEthUsdPrice(fixedPrice);
+    }
+
     function testFuzzSetFixedEthUsdPriceOverridesPriceFeed(uint256 fixedPrice) public {
         fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         vm.assume(fixedPrice != storageRegistry.ethUsdPrice());


### PR DESCRIPTION
## Motivation

Coverage showed that we missed tests for the `InvalidFixedPrice` error.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding new test functions for the `StorageRegistry` contract.

### Detailed summary:
- Added a new test function `testFuzzSetFixedEthUsdPriceRevertsLessThanMinPrice` to check if setting a fixed ETH/USD price below the minimum price reverts the transaction.
- Added a new test function `testFuzzSetFixedEthUsdPriceRevertsGreaterThanMaxPrice` to check if setting a fixed ETH/USD price above the maximum price reverts the transaction.
- Added a new test function `testFuzzSetFixedEthUsdPriceOverridesPriceFeed` to check if setting a fixed ETH/USD price overrides the price feed value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->