### PR TITLE
fix: Don't pin version for foundryup

### DIFF
--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -11,7 +11,5 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 
 ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
 
-# Hardcode release so that we don't have surprising breakages when rebuilding by
-# automatically downloading the latest release every time.
-# https://github.com/foundry-rs/foundry/releases/tag/nightly-d4f626bb7f96d46358997d4b27f79358cb2b3401
-RUN foundryup --version nightly-d4f626bb7f96d46358997d4b27f79358cb2b3401
+# TODO: Install a specific version so builds don't unexpected break in the future
+RUN foundryup


### PR DESCRIPTION
## Motivation

This doesn't seem to work on other people's machines, but it works on mine. For now, just install the latest.

## Change Summary

Updated the `foundryup` call at the end of the `Dockerfile.foundry` build.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)
