### PR TITLE
fix: update deploy scripts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,6 +15,7 @@ libs = ["node_modules", "lib"]
 [profile.ci]
 verbosity = 3
 fuzz = { runs = 2000 }
+no_match_path = ""
 match_path = "test/*/**"
 
 [fmt]

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -59,9 +59,7 @@ contract Deploy is ImmutableCreate2Deployer {
                 params.roleAdmin,
                 params.admin,
                 params.operator,
-                params.treasurer,
-                INITIAL_PRICE_FEED_CACHE_DURATION,
-                INITIAL_UPTIME_FEED_GRACE_PERIOD
+                params.treasurer
             )
         );
         address idRegistry = register(
@@ -74,7 +72,7 @@ contract Deploy is ImmutableCreate2Deployer {
             "KeyRegistry",
             KEY_REGISTRY_CREATE2_SALT,
             type(KeyRegistry).creationCode,
-            abi.encode(idRegistry, KEY_REGISTRY_MIGRATION_GRACE_PERIOD, params.initialKeyRegistryOwner)
+            abi.encode(idRegistry, params.initialKeyRegistryOwner)
         );
         address bundler = register(
             "Bundler",


### PR DESCRIPTION
## Motivation

We made some recent changes to the `KeyRegistry` and `StorageRegistry` constructor args that weren't reflected in the deployment script. 

We have a [fork test](https://github.com/farcasterxyz/contracts/blob/main/test/Deploy/Deploy.t.sol) that's meant to run on CI to test the deploy script, but it turns out our `foundry.toml` was misconfigured and it was being skipped.

## Change Summary

Update constructor args in `Deploy.s.sol`. Add an empty `no_match_path` rule to the Foundry CI profile to override the default and match all tests.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)
