### PR TITLE
chore: Add support for toggling blank slate vs forked chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,12 @@ FNAME_RESOLVER_SERVER_URL=https://fnames.farcaster.xyz/ccip/{sender}/{data}.json
 FNAME_RESOLVER_SIGNER_ADDRESS=0xBc5274eFc266311015793d89E9B591fa46294741
 FNAME_RESOLVER_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
-# RPC endpoints for OP testnet and mainnet.
+# RPC endpoints for OP testnet and mainnet. If you don't specify these, the
+# container will default to a "blank slate" using the CHAIN_ID environment
+# variable for the chain.
 TESTNET_RPC_URL=
 MAINNET_RPC_URL=
+CHAIN_ID=10
 
 # Deployer address.
 # Default address is Anvil test account 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,20 @@ services:
     build:
       dockerfile: Dockerfile.foundry
       context: .
-    entrypoint: ""
-    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--retries', '3', '--timeout', '10000']
+    command: |
+      sh -c '
+        set -e
+        command_args="--host 0.0.0.0 --port ${PORT:-8545} --state /var/lib/anvil/state"
+        if [ -n "$$MAINNET_RPC_URL" ]; then
+          echo "Starting Anvil from a forked chain"
+          exec anvil $$command_args --rpc-url $$MAINNET_RPC_URL --retries 3 --timeout 10000
+        else
+          echo "Starting Anvil with a blank slate chain"
+          exec anvil $$command_args --chain-id $$CHAIN_ID
+        fi
+      '
     environment:
+      - CHAIN_ID
       - MAINNET_RPC_URL
     volumes:
       - anvil-data:/var/lib/anvil


### PR DESCRIPTION
## Motivation

We want the ability to start anvil either in forked mode or as a blank slate (for CI tests). Add the logic.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding the option to specify RPC endpoints for the OP testnet and mainnet, and the chain ID for the Anvil container.

### Detailed summary:
- Added `TESTNET_RPC_URL` and `MAINNET_RPC_URL` environment variables to specify RPC endpoints.
- Added `CHAIN_ID` environment variable to specify the chain ID.
- Modified the `command` in `docker-compose.yml` to handle different scenarios based on the presence of `MAINNET_RPC_URL` and `CHAIN_ID` variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->