### PR TITLE
chore: add forge install to docker startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
         echo "Enabling impersonation"
         cast rpc anvil_autoImpersonateAccount true --rpc-url "$$RPC_URL" > /dev/null
         echo "Deploying contract"
+        forge install
         forge script -v script/Deploy.s.sol --rpc-url "$$RPC_URL" --unlocked --broadcast --sender "$$DEPLOYER"
         echo "Disabling impersonation"
         cast rpc anvil_autoImpersonateAccount false --rpc-url "$$RPC_URL" > /dev/null


### PR DESCRIPTION
## Motivation

The `contracts-deployer` docker-compose service fails if the user hasn't installed forge dependencies in their local repository.

## Change Summary

Add a `forge install` step to the `contracts-deployer` startup script.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deploying a contract and disabling impersonation. 

### Detailed summary
- Added `forge install` command for deployment
- Added `forge script` command for executing a script
- Added `cast rpc` command for enabling and disabling impersonation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->