### PR TITLE
fix: Revert "chore: Add support for toggling blank slate vs forked chain (#356)"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,12 +30,9 @@ FNAME_RESOLVER_SERVER_URL=https://fnames.farcaster.xyz/ccip/{sender}/{data}.json
 FNAME_RESOLVER_SIGNER_ADDRESS=0xBc5274eFc266311015793d89E9B591fa46294741
 FNAME_RESOLVER_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
-# RPC endpoints for OP testnet and mainnet. If you don't specify these, the
-# container will default to a "blank slate" using the CHAIN_ID environment
-# variable for the chain.
+# RPC endpoints for OP testnet and mainnet.
 TESTNET_RPC_URL=
 MAINNET_RPC_URL=
-CHAIN_ID=10
 
 # Deployer address.
 # Default address is Anvil test account 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,20 +5,9 @@ services:
     build:
       dockerfile: Dockerfile.foundry
       context: .
-    command: |
-      sh -c '
-        set -e
-        command_args="--host 0.0.0.0 --port ${PORT:-8545} --state /var/lib/anvil/state"
-        if [ -n "$$MAINNET_RPC_URL" ]; then
-          echo "Starting Anvil from a forked chain"
-          exec anvil $$command_args --rpc-url $$MAINNET_RPC_URL --retries 3 --timeout 10000
-        else
-          echo "Starting Anvil with a blank slate chain"
-          exec anvil $$command_args --chain-id $$CHAIN_ID
-        fi
-      '
+    entrypoint: ""
+    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--retries', '3', '--timeout', '10000']
     environment:
-      - CHAIN_ID
       - MAINNET_RPC_URL
     volumes:
       - anvil-data:/var/lib/anvil


### PR DESCRIPTION
## Motivation

This reverts commit aabc0aa4e61d317423bbeb0a88417a020aafc4c9.

Turns out that this won't work with our deploy script since we depend on a contract that has already been deployed to OP Mainnet.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the deployment configuration for Anvil. 

### Detailed summary
- Removed the `CHAIN_ID` environment variable.
- Updated the `docker-compose.yml` file to use a different command format for starting Anvil.
- Removed the `CHAIN_ID` and `MAINNET_RPC_URL` environment variables from the `environment` section.
- Updated the volume mapping for the Anvil data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->