### PR TITLE
chore: key validator followups

### DIFF
--- a/src/validators/SignedKeyRequestValidator.sol
+++ b/src/validators/SignedKeyRequestValidator.sol
@@ -16,10 +16,10 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
     /**
      *  @notice Signed key request specific metadata.
      *
-     *  @param requestingFid The fid of the entity requesting to add
+     *  @param requestFid    The fid of the entity requesting to add
      *                       a signer key.
      *  @param requestSigner Signer address. Must be the owner of
-     *                       the requestingFid fid.
+     *                       requestFid.
      *  @param signature     EIP-712 SignedKeyRequest signature.
      *  @param deadline      block.timestamp after which signature expires.
      */
@@ -96,6 +96,7 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
 
         if (idRegistry.idOf(signedKeyRequest.requestSigner) != signedKeyRequest.requestFid) return false;
         if (block.timestamp > signedKeyRequest.deadline) return false;
+        if (key.length != 32) return false;
 
         return idRegistry.verifyFidSignature(
             signedKeyRequest.requestSigner,
@@ -112,11 +113,15 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
     }
 
     /*//////////////////////////////////////////////////////////////
-                            EIP-712 HELPERS
+                              HELPERS
     //////////////////////////////////////////////////////////////*/
 
     function hashTypedDataV4(bytes32 structHash) external view returns (bytes32) {
         return _hashTypedDataV4(structHash);
+    }
+
+    function encodeMetadata(SignedKeyRequest calldata metadata) external pure returns (bytes memory) {
+        return abi.encode(metadata);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/Bundler/Bundler.gas.t.sol
+++ b/test/Bundler/Bundler.gas.t.sol
@@ -4,11 +4,16 @@ pragma solidity 0.8.21;
 import "forge-std/Test.sol";
 
 import {Bundler} from "../../src/Bundler.sol";
-import {BundlerTestSuite} from "./BundlerTestSuite.sol";
+import {BundlerTestSuite, StorageRegistryTestSuite, KeyRegistryTestSuite} from "./BundlerTestSuite.sol";
 
 /* solhint-disable state-visibility */
 
 contract BundleRegistryGasUsageTest is BundlerTestSuite {
+    function setUp() public override {
+        super.setUp();
+        _registerValidator(1, 1);
+    }
+
     function testGasRegisterWithSig() public {
         vm.prank(owner);
         idRegistry.disableTrustedOnly();

--- a/test/Bundler/BundlerTestSuite.sol
+++ b/test/Bundler/BundlerTestSuite.sol
@@ -15,7 +15,7 @@ abstract contract BundlerTestSuite is StorageRegistryTestSuite, KeyRegistryTestS
     // Instance of the BundleRegistry contract wrapped in its test wrapper
     BundlerHarness bundler;
 
-    function setUp() public override(StorageRegistryTestSuite, KeyRegistryTestSuite) {
+    function setUp() public virtual override(StorageRegistryTestSuite, KeyRegistryTestSuite) {
         super.setUp();
 
         // Set up the BundleRegistry

--- a/test/Deploy/Deploy.t.sol
+++ b/test/Deploy/Deploy.t.sol
@@ -124,7 +124,8 @@ contract DeployTest is Test {
         uint256 requestFid = idRegistry.trustedRegister(app, address(0));
         uint256 deadline = block.timestamp + 60;
 
-        bytes memory sig = _signMetadata(appPk, requestFid, "key", deadline);
+        bytes memory key = bytes.concat("key", bytes29(0));
+        bytes memory sig = _signMetadata(appPk, requestFid, key, deadline);
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
                 requestFid: requestFid,
@@ -135,7 +136,7 @@ contract DeployTest is Test {
         );
 
         vm.prank(bundlerTrustedCaller);
-        bundler.trustedRegister(alice, bob, 1, "key", 1, metadata, 1);
+        bundler.trustedRegister(alice, bob, 1, key, 1, metadata, 1);
         assertEq(idRegistry.idOf(alice), 2);
 
         vm.startPrank(owner);

--- a/test/KeyRegistry/KeyRegistry.integration.t.sol
+++ b/test/KeyRegistry/KeyRegistry.integration.t.sol
@@ -79,6 +79,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         signerPk = _boundPk(signerPk);
         uint256 deadline = _boundDeadline(_deadline);
         address signer = vm.addr(signerPk);
+        vm.assume(signer != to);
 
         uint256 requestFid = _register(signer);
 

--- a/test/KeyRegistry/KeyRegistry.integration.t.sol
+++ b/test/KeyRegistry/KeyRegistry.integration.t.sol
@@ -31,16 +31,20 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         bytes metadata
     );
 
-    function testFuzzAdd(address to, uint256 signerPk, address recovery, bytes calldata key, uint40 _deadline) public {
+    function testFuzzAdd(
+        address to,
+        uint256 signerPk,
+        address recovery,
+        bytes calldata _keyBytes,
+        uint40 _deadline
+    ) public {
         signerPk = _boundPk(signerPk);
         uint256 deadline = _boundDeadline(_deadline);
         address signer = vm.addr(signerPk);
 
         uint256 userFid = _registerFid(to, recovery);
         uint256 requestFid = _register(signer);
-
-        uint32 keyType = 1;
-        uint8 metadataType = 1;
+        bytes memory key = _validKey(_keyBytes);
 
         bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
 
@@ -54,11 +58,77 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         );
 
         vm.expectEmit();
-        emit Add(userFid, keyType, key, key, metadataType, metadata);
+        emit Add(userFid, 1, key, key, 1, metadata);
         vm.prank(to);
-        keyRegistry.add(keyType, key, metadataType, metadata);
+        keyRegistry.add(1, key, 1, metadata);
 
-        assertAdded(userFid, key, keyType);
+        assertAdded(userFid, key, 1);
+    }
+
+    function testFuzzAddRevertsShortKey(
+        address to,
+        uint256 signerPk,
+        address recovery,
+        bytes calldata _keyBytes,
+        uint40 _deadline,
+        uint8 _shortenBy
+    ) public {
+        _registerFid(to, recovery);
+        bytes memory key = _shortKey(_keyBytes, _shortenBy);
+
+        signerPk = _boundPk(signerPk);
+        uint256 deadline = _boundDeadline(_deadline);
+        address signer = vm.addr(signerPk);
+
+        uint256 requestFid = _register(signer);
+
+        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+
+        bytes memory metadata = abi.encode(
+            SignedKeyRequestValidator.SignedKeyRequest({
+                requestFid: requestFid,
+                requestSigner: signer,
+                signature: sig,
+                deadline: deadline
+            })
+        );
+
+        vm.expectRevert(KeyRegistry.InvalidMetadata.selector);
+        vm.prank(to);
+        keyRegistry.add(1, key, 1, metadata);
+    }
+
+    function testFuzzAddRevertsLongKey(
+        address to,
+        uint256 signerPk,
+        address recovery,
+        bytes calldata _keyBytes,
+        uint40 _deadline,
+        uint8 _lengthenBy
+    ) public {
+        _registerFid(to, recovery);
+        bytes memory key = _longKey(_keyBytes, _lengthenBy);
+
+        signerPk = _boundPk(signerPk);
+        uint256 deadline = _boundDeadline(_deadline);
+        address signer = vm.addr(signerPk);
+
+        uint256 requestFid = _register(signer);
+
+        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+
+        bytes memory metadata = abi.encode(
+            SignedKeyRequestValidator.SignedKeyRequest({
+                requestFid: requestFid,
+                requestSigner: signer,
+                signature: sig,
+                deadline: deadline
+            })
+        );
+
+        vm.expectRevert(KeyRegistry.InvalidMetadata.selector);
+        vm.prank(to);
+        keyRegistry.add(1, key, 1, metadata);
     }
 
     function testFuzzAddRevertsInvalidSig(

--- a/test/KeyRegistry/KeyRegistry.t.sol
+++ b/test/KeyRegistry/KeyRegistry.t.sol
@@ -89,10 +89,6 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyType = uint32(bound(keyType, 1, type(uint32).max));
         metadataType = uint8(bound(metadataType, 1, type(uint8).max));
 
-        /* We set a validator for keyType 1, type 1 during setup. Remove it.*/
-        vm.prank(owner);
-        keyRegistry.setValidator(1, 1, IMetadataValidator(address(0)));
-
         uint256 fid = _registerFid(to, recovery);
 
         vm.prank(to);
@@ -744,13 +740,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                                 BULK ADD
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzBulkAddSignerForMigration(
-        uint256[] memory _ids,
-        uint8 _numKeys,
-        uint8 metadataType,
-        bytes memory metadata
-    ) public {
-        metadataType = uint8(bound(metadataType, 1, type(uint8).max));
+    function testFuzzBulkAddSignerForMigration(uint256[] memory _ids, uint8 _numKeys, bytes memory metadata) public {
+        _registerValidator(1, 1);
 
         vm.assume(_ids.length > 0);
         uint256 len = bound(_ids.length, 1, 100);
@@ -759,8 +750,6 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         uint256[] memory ids = _dedupeFuzzedIds(_ids, len);
         uint256 idsLength = ids.length;
         bytes[][] memory keys = _constructKeys(idsLength, numKeys);
-
-        _registerValidator(1, metadataType);
 
         vm.prank(owner);
         keyRegistry.bulkAddKeysForMigration(ids, keys, metadata);
@@ -773,6 +762,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testBulkAddEmitsEvent() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](3);
         bytes[][] memory keys = new bytes[][](3);
         bytes memory metadata = abi.encodePacked(uint8(1));
@@ -842,6 +833,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testBulkAddCannotReAdd() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](2);
         bytes[][] memory keys = new bytes[][](2);
         bytes memory metadata = abi.encodePacked(uint8(1));
@@ -866,6 +859,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testFuzzBulkAddSignerForMigrationRevertsMismatchedInput() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](2);
         bytes[][] memory keys = new bytes[][](1);
         bytes memory metadata = abi.encodePacked(uint8(1));
@@ -884,10 +879,10 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     function testFuzzBulkRemoveSignerForMigration(
         uint256[] memory _ids,
         uint8 _numKeys,
-        uint8 metadataType,
         bytes memory metadata
     ) public {
-        metadataType = uint8(bound(metadataType, 1, type(uint8).max));
+        _registerValidator(1, 1);
+
         vm.assume(_ids.length > 0);
         uint256 len = bound(_ids.length, 1, 100);
         uint256 numKeys = bound(_numKeys, 1, 10);
@@ -895,8 +890,6 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         uint256[] memory ids = _dedupeFuzzedIds(_ids, len);
         uint256 idsLength = ids.length;
         bytes[][] memory keys = _constructKeys(idsLength, numKeys);
-
-        _registerValidator(1, metadataType);
 
         vm.startPrank(owner);
 
@@ -913,6 +906,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testBulkResetEmitsEvent() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](3);
         bytes[][] memory keys = new bytes[][](3);
         bytes memory metadata = abi.encodePacked(uint8(1));
@@ -954,6 +949,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testBulkResetRevertsWithoutAdding() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](2);
         bytes[][] memory keys = new bytes[][](2);
 
@@ -972,6 +969,8 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     }
 
     function testBulkResetRevertsIfRunTwice() public {
+        _registerValidator(1, 1);
+
         uint256[] memory ids = new uint256[](2);
         bytes[][] memory keys = new bytes[][](2);
         bytes memory metadata = abi.encodePacked(uint8(1));
@@ -1100,10 +1099,6 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
     function testFuzzSetValidator(uint32 keyType, uint8 metadataType, IMetadataValidator validator) public {
         keyType = uint32(bound(keyType, 1, type(uint32).max));
         metadataType = uint8(bound(metadataType, 1, type(uint8).max));
-
-        /* We set a validator for keyType 1, type 1 during setup. Remove it.*/
-        vm.prank(owner);
-        keyRegistry.setValidator(1, 1, IMetadataValidator(address(0)));
 
         assertEq(address(keyRegistry.validators(keyType, metadataType)), address(0));
 

--- a/test/KeyRegistry/KeyRegistryTestSuite.sol
+++ b/test/KeyRegistry/KeyRegistryTestSuite.sol
@@ -18,9 +18,6 @@ abstract contract KeyRegistryTestSuite is IdRegistryTestSuite {
 
         keyRegistry = new KeyRegistryHarness(address(idRegistry), owner);
         stubValidator = new StubValidator();
-
-        vm.prank(owner);
-        keyRegistry.setValidator(1, 1, IMetadataValidator(address(stubValidator)));
     }
 
     function _signAdd(

--- a/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
+++ b/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
@@ -17,16 +17,21 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
                               VALIDATION
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzValidate(uint256 signerPk, uint256 userFid, bytes calldata _keyBytes, uint40 _deadline) public {
-        signerPk = _boundPk(signerPk);
+    function testFuzzValidate(
+        uint256 requesterPk,
+        uint256 userFid,
+        bytes calldata _keyBytes,
+        uint40 _deadline
+    ) public {
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
 
         bytes memory key = _validKey(_keyBytes);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -43,21 +48,21 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateShortKey(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         uint40 _deadline,
         uint8 _shortenBy
     ) public {
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
 
         bytes memory key = _shortKey(_keyBytes, _shortenBy);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -74,21 +79,21 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateLongKey(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         uint40 _deadline,
         uint8 _lengthenBy
     ) public {
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
 
         bytes memory key = _longKey(_keyBytes, _lengthenBy);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -105,20 +110,20 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateUnownedAppFid(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         uint40 _deadline
     ) public {
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
         uint256 unownedFid = requestFid + 1;
         bytes memory key = _validKey(_keyBytes);
 
-        bytes memory sig = _signMetadata(signerPk, unownedFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, unownedFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -135,21 +140,21 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateWrongSigner(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         address wrongSigner,
         uint40 _deadline
     ) public {
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         vm.assume(wrongSigner != signer);
         uint256 requestFid = _register(signer);
         bytes memory key = _validKey(_keyBytes);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -166,21 +171,21 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateExpired(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         uint256 wrongUserFid,
         uint40 _deadline
     ) public {
         vm.assume(wrongUserFid != userFid);
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
         bytes memory key = _validKey(_keyBytes);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -199,7 +204,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateWrongPubKey(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         bytes calldata wrongPubKey,
@@ -207,13 +212,13 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     ) public {
         bytes memory key = _validKey(_keyBytes);
         vm.assume(keccak256(wrongPubKey) != keccak256(key));
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
 
-        bytes memory sig = _signMetadata(signerPk, requestFid, wrongPubKey, deadline);
+        bytes memory sig = _signMetadata(requesterPk, requestFid, wrongPubKey, deadline);
 
         bytes memory metadata = abi.encode(
             SignedKeyRequestValidator.SignedKeyRequest({
@@ -230,15 +235,15 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
     }
 
     function testFuzzValidateBadSig(
-        uint256 signerPk,
+        uint256 requesterPk,
         uint256 userFid,
         bytes calldata _keyBytes,
         uint40 _deadline
     ) public {
-        signerPk = _boundPk(signerPk);
+        requesterPk = _boundPk(requesterPk);
         uint256 deadline = _boundDeadline(_deadline);
 
-        address signer = vm.addr(signerPk);
+        address signer = vm.addr(requesterPk);
         uint256 requestFid = _register(signer);
         bytes memory key = _validKey(_keyBytes);
 

--- a/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidatorTestSuite.sol
+++ b/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidatorTestSuite.sol
@@ -19,6 +19,36 @@ abstract contract SignedKeyRequestValidatorTestSuite is IdRegistryTestSuite {
         );
     }
 
+    function _validKey(bytes memory keyBytes) internal pure returns (bytes memory) {
+        if (keyBytes.length < 32) {
+            // pad with zero bytes
+            bytes memory padding = new bytes(32 - keyBytes.length);
+            return bytes.concat(keyBytes, padding);
+        } else if (keyBytes.length > 32) {
+            // truncate length
+            assembly {
+                mstore(keyBytes, 32)
+            }
+            return keyBytes;
+        } else {
+            return keyBytes;
+        }
+    }
+
+    function _shortKey(bytes memory keyBytes, uint8 _amount) internal view returns (bytes memory) {
+        uint256 amount = bound(_amount, 0, 31);
+        assembly {
+            mstore(keyBytes, amount)
+        }
+        return keyBytes;
+    }
+
+    function _longKey(bytes memory keyBytes, uint8 _amount) internal view returns (bytes memory) {
+        uint256 amount = bound(_amount, 1, type(uint8).max);
+        bytes memory padding = new bytes(amount);
+        return bytes.concat(_validKey(keyBytes), padding);
+    }
+
     function _signMetadata(
         uint256 pk,
         uint256 requestingFid,


### PR DESCRIPTION
## Motivation

Followups from #354 

## Change Summary

- Validate that key length is exactly 32 bytes
- Add `encodeMetadata` view to `SignedKeyRequestValidator`. This exposes the `SignedKeyRequest` struct in the contract ABI for clients like Viem and can be called directly to encode metadata.
- Use the `_registerValidator` helper to explicitly set up validators in all tests, rather than rely on implicit `setUp`
- Comment cleanup

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making changes to the KeyRegistry, Bundler, and SignedKeyRequestValidator contracts. 

### Detailed summary
- Added virtual modifier to the setUp() function in BundlerTestSuite.sol
- Updated import statements in Bundler.gas.t.sol
- Added helper functions in SignedKeyRequestValidator.sol
- Modified the _signAdd() function in BundlerTestSuite.sol
- Updated the _signMetadata() function in SignedKeyRequestValidator.sol
- Made changes to the testFuzzAdd() function in KeyRegistry.integration.t.sol
- Made changes to the testFuzzAddRevertsShortKey() function in KeyRegistry.integration.t.sol
- Made changes to the testFuzzAddRevertsLongKey() function in KeyRegistry.integration.t.sol
- Updated the metadata parameter in the testFuzzAdd() function in KeyRegistry.integration.t.sol
- Updated the metadataType parameter in the testFuzzBulkAddSignerForMigration() function in KeyRegistry.t.sol
- Updated the metadataType parameter in the testFuzzBulkRemoveSignerForMigration() function in KeyRegistry.t.sol
- Updated the signerPk parameter to requesterPk in the testFuzzValidate() function in SignedKeyRequestValidator.t.sol

> The following files were skipped due to too many changes: `test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->