### PR TITLE
chore: update SignedKeyRequestValidator name

### DIFF
--- a/src/validators/SignedKeyRequestValidator.sol
+++ b/src/validators/SignedKeyRequestValidator.sol
@@ -68,7 +68,7 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
      * @param _idRegistry   IdRegistry contract address.
      * @param _initialOwner Initial contract owner address.
      */
-    constructor(address _idRegistry, address _initialOwner) EIP712("Farcaster MetadataValidator", "1") {
+    constructor(address _idRegistry, address _initialOwner) EIP712("Farcaster SignedKeyRequestValidator", "1") {
         idRegistry = IdRegistryLike(_idRegistry);
         _transferOwnership(_initialOwner);
     }


### PR DESCRIPTION
## Motivation

Rather than sharing one name for all validators, it's clearer to use the validator's specific type.

## Change Summary

Use a metadata type-specific `name` in the `SignedKeyRequestValidator`'s EIP-712 domain separator. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the constructor name in `SignedKeyRequestValidator.sol` to reflect the change in contract name. 

### Detailed summary
- Updated the constructor name from "Farcaster MetadataValidator" to "Farcaster SignedKeyRequestValidator".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->