### PR TITLE
fix: add metadata to KeyRegistry batches

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,6 +1,6 @@
 BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 834117)
-BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 7070301)
-BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 914503)
+BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 7068101)
+BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 914283)
 IdRegistryGasUsageTest:testGasRegister() (gas: 736116)
 IdRegistryGasUsageTest:testGasRegisterForAndRecover() (gas: 1743798)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 809179)

--- a/test/Deploy/Deploy.t.sol
+++ b/test/Deploy/Deploy.t.sol
@@ -127,7 +127,7 @@ contract DeployTest is Test {
         bytes memory key = bytes.concat("key", bytes29(0));
         bytes memory sig = _signMetadata(appPk, requestFid, key, deadline);
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: app,
                 signature: sig,

--- a/test/KeyRegistry/KeyRegistry.integration.t.sol
+++ b/test/KeyRegistry/KeyRegistry.integration.t.sol
@@ -49,7 +49,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -86,7 +86,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -119,7 +119,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         bytes memory sig = _signMetadata(signerPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -152,7 +152,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         bytes memory sig = _signMetadata(otherPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,

--- a/test/KeyRegistry/KeyRegistryTestHelpers.sol
+++ b/test/KeyRegistry/KeyRegistryTestHelpers.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {KeyRegistry} from "../../src/KeyRegistry.sol";
+
+library BulkAddDataBuilder {
+    function empty() internal pure returns (KeyRegistry.BulkAddData[] memory) {
+        return new KeyRegistry.BulkAddData[](0);
+    }
+
+    function addFid(
+        KeyRegistry.BulkAddData[] memory addData,
+        uint256 fid
+    ) internal pure returns (KeyRegistry.BulkAddData[] memory) {
+        KeyRegistry.BulkAddData[] memory newData = new KeyRegistry.BulkAddData[](addData.length + 1);
+        for (uint256 i; i < addData.length; i++) {
+            newData[i] = addData[i];
+        }
+        newData[addData.length].fid = fid;
+        return newData;
+    }
+
+    function addKey(
+        KeyRegistry.BulkAddData[] memory addData,
+        uint256 index,
+        bytes memory key,
+        bytes memory metadata
+    ) internal pure returns (KeyRegistry.BulkAddData[] memory) {
+        KeyRegistry.BulkAddKey[] memory keys = addData[index].keys;
+        KeyRegistry.BulkAddKey[] memory newKeys = new KeyRegistry.BulkAddKey[](
+            keys.length + 1
+        );
+
+        for (uint256 i; i < keys.length; i++) {
+            newKeys[i] = keys[i];
+        }
+        newKeys[keys.length].key = key;
+        newKeys[keys.length].metadata = metadata;
+        addData[index].keys = newKeys;
+        return addData;
+    }
+}
+
+library BulkResetDataBuilder {
+    function empty() internal pure returns (KeyRegistry.BulkResetData[] memory) {
+        return new KeyRegistry.BulkResetData[](0);
+    }
+
+    function addFid(
+        KeyRegistry.BulkResetData[] memory removeData,
+        uint256 fid
+    ) internal pure returns (KeyRegistry.BulkResetData[] memory) {
+        KeyRegistry.BulkResetData[] memory newData = new KeyRegistry.BulkResetData[](
+                removeData.length + 1
+            );
+        for (uint256 i; i < removeData.length; i++) {
+            newData[i] = removeData[i];
+        }
+        newData[removeData.length].fid = fid;
+        return newData;
+    }
+
+    function addKey(
+        KeyRegistry.BulkResetData[] memory removeData,
+        uint256 index,
+        bytes memory key
+    ) internal pure returns (KeyRegistry.BulkResetData[] memory) {
+        bytes[] memory prevKeys = removeData[index].keys;
+        bytes[] memory newKeys = new bytes[](prevKeys.length + 1);
+
+        for (uint256 i; i < prevKeys.length; i++) {
+            newKeys[i] = prevKeys[i];
+        }
+        newKeys[prevKeys.length] = key;
+        removeData[index].keys = newKeys;
+        return removeData;
+    }
+}

--- a/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
+++ b/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
@@ -34,7 +34,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -65,7 +65,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -96,7 +96,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -126,7 +126,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, unownedFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: unownedFid,
                 requestSigner: signer,
                 signature: sig,
@@ -157,7 +157,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: wrongSigner,
                 signature: sig,
@@ -188,7 +188,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, key, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -221,7 +221,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = _signMetadata(requesterPk, requestFid, wrongPubKey, deadline);
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -251,7 +251,7 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes memory sig = abi.encodePacked(bytes32("bad sig"), bytes32(0), bytes1(0));
 
         bytes memory metadata = abi.encode(
-            SignedKeyRequestValidator.SignedKeyRequest({
+            SignedKeyRequestValidator.SignedKeyRequestMetadata({
                 requestFid: requestFid,
                 requestSigner: signer,
                 signature: sig,
@@ -274,7 +274,8 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         bytes calldata signature,
         uint256 deadline
     ) public {
-        SignedKeyRequestValidator.SignedKeyRequest memory request = SignedKeyRequestValidator.SignedKeyRequest({
+        SignedKeyRequestValidator.SignedKeyRequestMetadata memory request = SignedKeyRequestValidator
+            .SignedKeyRequestMetadata({
             requestFid: requestFid,
             requestSigner: requestSigner,
             signature: signature,
@@ -282,8 +283,8 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         });
 
         bytes memory encoded = validator.encodeMetadata(request);
-        SignedKeyRequestValidator.SignedKeyRequest memory decoded =
-            abi.decode(encoded, (SignedKeyRequestValidator.SignedKeyRequest));
+        SignedKeyRequestValidator.SignedKeyRequestMetadata memory decoded =
+            abi.decode(encoded, (SignedKeyRequestValidator.SignedKeyRequestMetadata));
 
         assertEq(request.requestFid, decoded.requestFid);
         assertEq(request.requestSigner, decoded.requestSigner);


### PR DESCRIPTION
## Motivation

Now that adding key metadata requires a unique signature per key, we need to add metadata to the batch migration functions.

## Change Summary

Update `bulkAddKeysForMigration` add to include per-key metadata in each batch. Refactor to struct args for both `bulkAddKeysForMigration` and `bulkAddKeysForMigration`, instead of separate data arrays.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

- Creating these batch structs in tests is painful, since they include arrays of items that need to be initialized an manipulated separately. I've added a couple builder libraries in `KeyRegistryTestHelpers` that make it easier to construct batches in tests.