### PR TITLE
chore: update deployment parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ ID_REGISTRY_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 # Default address is Anvil test account 1
 KEY_REGISTRY_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
+# Metadata validator params
+# Default address is Anvil test account 1
+METADATA_VALIDATOR_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
 # Bundler params
 # Default addresses are Anvil test account 1
 BUNDLER_TRUSTED_CALLER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,7 @@ libs = ["node_modules", "lib"]
 
 [profile.ci]
 verbosity = 3
-fuzz = { runs = 2000 }
+fuzz = { runs = 1500 }
 no_match_path = ""
 match_path = "test/*/**"
 

--- a/script/lib/ImmutableCreate2Deployer.sol
+++ b/script/lib/ImmutableCreate2Deployer.sol
@@ -132,11 +132,15 @@ abstract contract ImmutableCreate2Deployer is Script {
     /**
      * @dev Deploy all registered contracts.
      */
-    function deploy() internal {
+    function deploy(bool broadcast) internal {
         console.log(pad("State", 10), pad("Name", 27), pad("Address", 43), "Initcode hash");
         for (uint256 i; i < names.length; i++) {
-            _deploy(names[i]);
+            _deploy(names[i], broadcast);
         }
+    }
+
+    function deploy() internal {
+        deploy(true);
     }
 
     /**
@@ -144,15 +148,19 @@ abstract contract ImmutableCreate2Deployer is Script {
      *
      * @param name Contract name
      */
-    function deploy(string memory name) internal {
+    function deploy(string memory name, bool broadcast) public {
         console.log(pad("State", 10), pad("Name", 17), pad("Address", 43), "Initcode hash");
-        _deploy(name);
+        _deploy(name, broadcast);
     }
 
-    function _deploy(string memory name) internal {
+    function deploy(string memory name) internal {
+        deploy(name, true);
+    }
+
+    function _deploy(string memory name, bool broadcast) internal {
         Deployment storage deployment = contracts[name];
         if (!IMMUTABLE_CREATE2_FACTORY.hasBeenDeployed(deployment.deploymentAddress)) {
-            vm.broadcast();
+            if (broadcast) vm.broadcast();
             deployment.deploymentAddress = IMMUTABLE_CREATE2_FACTORY.safeCreate2(
                 deployment.salt, bytes.concat(deployment.creationCode, deployment.constructorArgs)
             );

--- a/test/Deploy/Deploy.t.sol
+++ b/test/Deploy/Deploy.t.sol
@@ -11,11 +11,11 @@ import {
     Bundler,
     IMetadataValidator
 } from "../../script/Deploy.s.sol";
+import "forge-std/console.sol";
 
 /* solhint-disable state-visibility */
 
-contract DeployTest is Test {
-    Deploy internal deploy;
+contract DeployTest is Deploy, Test {
     StorageRegistry internal storageRegistry;
     IdRegistry internal idRegistry;
     KeyRegistry internal keyRegistry;
@@ -37,13 +37,11 @@ contract DeployTest is Test {
     address internal app;
     uint256 internal appPk;
 
-    address internal owner = makeAddr("owner");
+    address internal deployer = address(this);
+    address internal alpha = makeAddr("alpha");
+    address internal beta = makeAddr("beta");
     address internal vault = makeAddr("vault");
-    address internal roleAdmin = makeAddr("roleAdmin");
-    address internal admin = makeAddr("admin");
-    address internal operator = makeAddr("operator");
-    address internal treasurer = makeAddr("treasurer");
-    address internal bundlerTrustedCaller = makeAddr("bundlerTrustedCaller");
+    address internal relayer = makeAddr("relayer");
 
     // @dev OP Mainnet ETH/USD price feed
     address internal priceFeed = address(0x13e3Ee699D1909E989722E753853AE30b17e08c5);
@@ -61,22 +59,23 @@ contract DeployTest is Test {
         (app, appPk) = makeAddrAndKey("app");
 
         Deploy.DeploymentParams memory params = Deploy.DeploymentParams({
-            initialIdRegistryOwner: owner,
-            initialKeyRegistryOwner: owner,
-            initialBundlerOwner: owner,
+            initialIdRegistryOwner: alpha,
+            initialKeyRegistryOwner: alpha,
+            initialBundlerOwner: alpha,
+            initialValidatorOwner: alpha,
             priceFeed: priceFeed,
             uptimeFeed: uptimeFeed,
             vault: vault,
-            roleAdmin: roleAdmin,
-            admin: admin,
-            operator: operator,
-            treasurer: treasurer,
-            bundlerTrustedCaller: bundlerTrustedCaller
+            roleAdmin: alpha,
+            admin: beta,
+            operator: relayer,
+            treasurer: relayer,
+            bundlerTrustedCaller: relayer,
+            deployer: deployer
         });
 
-        deploy = new Deploy();
-
-        Deploy.Contracts memory contracts = deploy.runDeploy(params);
+        Deploy.Contracts memory contracts = runDeploy(params, false);
+        runSetup(contracts, params, false);
 
         storageRegistry = contracts.storageRegistry;
         idRegistry = contracts.idRegistry;
@@ -89,36 +88,50 @@ contract DeployTest is Test {
         assertEq(address(storageRegistry.priceFeed()), priceFeed);
         assertEq(address(storageRegistry.uptimeFeed()), uptimeFeed);
         assertEq(storageRegistry.deprecationTimestamp(), block.timestamp + 365 days);
-        assertEq(storageRegistry.usdUnitPrice(), deploy.INITIAL_USD_UNIT_PRICE());
-        assertEq(storageRegistry.maxUnits(), deploy.INITIAL_MAX_UNITS());
-        assertEq(storageRegistry.priceFeedCacheDuration(), deploy.INITIAL_PRICE_FEED_CACHE_DURATION());
-        assertEq(storageRegistry.uptimeFeedGracePeriod(), deploy.INITIAL_UPTIME_FEED_GRACE_PERIOD());
+        assertEq(storageRegistry.usdUnitPrice(), INITIAL_USD_UNIT_PRICE);
+        assertEq(storageRegistry.maxUnits(), INITIAL_MAX_UNITS);
+        assertEq(storageRegistry.priceFeedCacheDuration(), INITIAL_PRICE_FEED_CACHE_DURATION);
+        assertEq(storageRegistry.uptimeFeedGracePeriod(), INITIAL_UPTIME_FEED_GRACE_PERIOD);
 
-        assertEq(idRegistry.owner(), owner);
+        assertEq(storageRegistry.getRoleMemberCount(bytes32(0)), 1);
+        assertEq(storageRegistry.hasRole(bytes32(0), deployer), false);
 
-        assertEq(keyRegistry.owner(), owner);
+        assertEq(storageRegistry.getRoleMemberCount(keccak256("OWNER_ROLE")), 1);
+        assertEq(storageRegistry.hasRole(keccak256("OWNER_ROLE"), deployer), false);
+        assertEq(storageRegistry.hasRole(keccak256("OWNER_ROLE"), beta), true);
+
+        assertEq(storageRegistry.getRoleMemberCount(keccak256("OPERATOR_ROLE")), 2);
+        assertEq(storageRegistry.hasRole(keccak256("OPERATOR_ROLE"), deployer), false);
+        assertEq(storageRegistry.hasRole(keccak256("OPERATOR_ROLE"), address(bundler)), true);
+        assertEq(storageRegistry.hasRole(keccak256("OPERATOR_ROLE"), relayer), true);
+
+        assertEq(storageRegistry.getRoleMemberCount(keccak256("TREASURER_ROLE")), 1);
+        assertEq(storageRegistry.hasRole(keccak256("TREASURER_ROLE"), deployer), false);
+        assertEq(storageRegistry.hasRole(keccak256("TREASURER_ROLE"), relayer), true);
+
+        assertEq(idRegistry.owner(), deployer);
+        assertEq(idRegistry.pendingOwner(), alpha);
+
+        assertEq(keyRegistry.owner(), deployer);
+        assertEq(keyRegistry.pendingOwner(), alpha);
         assertEq(address(keyRegistry.idRegistry()), address(idRegistry));
-        assertEq(keyRegistry.gracePeriod(), deploy.KEY_REGISTRY_MIGRATION_GRACE_PERIOD());
+        assertEq(keyRegistry.gracePeriod(), KEY_REGISTRY_MIGRATION_GRACE_PERIOD);
 
-        assertEq(validator.owner(), owner);
+        assertEq(validator.owner(), alpha);
         assertEq(address(validator.idRegistry()), address(idRegistry));
 
-        assertEq(bundler.owner(), owner);
+        assertEq(bundler.owner(), alpha);
         assertEq(address(bundler.idRegistry()), address(idRegistry));
         assertEq(address(bundler.storageRegistry()), address(storageRegistry));
         assertEq(address(bundler.keyRegistry()), address(keyRegistry));
-        assertEq(bundler.trustedCaller(), bundlerTrustedCaller);
+        assertEq(bundler.trustedCaller(), relayer);
     }
 
     function test_e2e() public {
-        vm.startPrank(owner);
-        idRegistry.setTrustedCaller(address(bundler));
-        keyRegistry.setTrustedCaller(address(bundler));
-        keyRegistry.setValidator(1, 1, IMetadataValidator(address(validator)));
+        vm.startPrank(alpha);
+        idRegistry.acceptOwnership();
+        keyRegistry.acceptOwnership();
         vm.stopPrank();
-
-        vm.prank(roleAdmin);
-        storageRegistry.grantRole(keccak256("OPERATOR_ROLE"), address(bundler));
 
         vm.prank(address(bundler));
         uint256 requestFid = idRegistry.trustedRegister(app, address(0));
@@ -137,11 +150,11 @@ contract DeployTest is Test {
 
         Bundler.SignerData[] memory signers = new Bundler.SignerData[](1);
         signers[0] = Bundler.SignerData({keyType: 1, key: key, metadataType: 1, metadata: metadata});
-        vm.prank(bundlerTrustedCaller);
+        vm.prank(relayer);
         bundler.trustedRegister(Bundler.UserData({to: alice, recovery: bob, signers: signers, units: 1}));
         assertEq(idRegistry.idOf(alice), 2);
 
-        vm.startPrank(owner);
+        vm.startPrank(alpha);
         idRegistry.disableTrustedOnly();
         keyRegistry.disableTrustedOnly();
         bundler.disableTrustedOnly();


### PR DESCRIPTION
## Motivation

Update the deployment script and tests with realistic deployment parameters.

## Change Summary

Update post-deployment setup to transfer ownership and roles to the right destination addresses. Update deployment tests to use `alpha`, `beta`, `relayer`, and `vault` addresses, rather than one test address per parameter. Set storage unit supply to 200k.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update the deployment logic and parameters in the `Deploy` contract.

### Detailed summary:
- Decreased the number of fuzz runs in the CI profile in the `foundry.toml` file.
- Added a new parameter `METADATA_VALIDATOR_OWNER_ADDRESS` in the `.env.example` file.
- Modified the `deploy` function in the `ImmutableCreate2Deployer.sol` file to accept a boolean parameter `broadcast`.
- Added a new `deploy` function in the `ImmutableCreate2Deployer.sol` file that calls the previous `deploy` function with `broadcast` set to `true`.
- Modified the `deploy` function in the `ImmutableCreate2Deployer.sol` file to accept a string parameter `name` and a boolean parameter `broadcast`.
- Added a new `deploy` function in the `ImmutableCreate2Deployer.sol` file that calls the previous `deploy` function with `broadcast` set to `true`.
- Modified the `runDeploy` function in the `Deploy` contract to accept a boolean parameter `broadcast`.
- Added a new `runDeploy` function in the `Deploy` contract that calls the previous `runDeploy` function with `broadcast` set to `true`.
- Added a new `runDeploy` function in the `Deploy` contract that accepts a `DeploymentParams` parameter and a boolean parameter `broadcast`.
- Modified the `runSetup` function in the `Deploy` contract to accept a `Contracts` parameter and a `DeploymentParams` parameter.
- Added a new `runSetup` function in the `Deploy` contract that calls the previous `runSetup` function with `broadcast` set to `true`.
- Added a new `runSetup` function in the `Deploy` contract that accepts a `Contracts` parameter and calls the previous `runSetup` function with `broadcast` set to `true`.
- Modified the `runSetup` function in the `DeployTest` contract to accept a `Contracts` parameter and a `DeploymentParams` parameter.
- Added a new `runSetup` function in the `DeployTest` contract that calls the previous `runSetup` function with `broadcast` set to `true`.
- Added a new `runSetup` function in the `DeployTest` contract that accepts a `Contracts` parameter and calls the previous `runSetup` function with `broadcast` set to `true`.
- Modified the `test_e2e` function in the `DeployTest` contract to use the `alpha` address instead of the `owner` address.
- Modified the `test_e2e` function in the `DeployTest` contract to call the `acceptOwnership` function for `idRegistry` and `keyRegistry`.
- Modified the `test_e2e` function in the `DeployTest` contract to use the `relayer` address instead of the `bundlerTrustedCaller` address.

> The following files were skipped due to too many changes: `test/Deploy/Deploy.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->