### PR TITLE
feat: add Pausable to KeyRegistry

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,6 +1,6 @@
 BundleRegistryGasUsageTest:testGasRegisterWithSig() (gas: 834117)
-BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 7068101)
-BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 914283)
+BundleRegistryGasUsageTest:testGasTrustedBatchRegister() (gas: 7091701)
+BundleRegistryGasUsageTest:testGasTrustedRegister() (gas: 918443)
 IdRegistryGasUsageTest:testGasRegister() (gas: 736116)
 IdRegistryGasUsageTest:testGasRegisterForAndRecover() (gas: 1743798)
 IdRegistryGasUsageTest:testGasRegisterFromTrustedCaller() (gas: 809179)


### PR DESCRIPTION
## Motivation

Like our other contracts, the `KeyRegistry` should be pausable in case of emergency.

## Change Summary

Add `Pausable` to `KeyRegistry`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `Pausable` contract from OpenZeppelin is imported and added to the `KeyRegistry` contract.
- The `pause()` and `unpause()` functions are added to the `KeyRegistry` contract.
- The `_registerFid()` function is modified to check if the contract is paused before adding a key.
- The `_remove()` and `_reset()` functions are modified to check if the contract is paused before removing/resetting a key.
- Tests for adding, removing, and resetting keys are modified to check if the contract is paused before performing the respective operation.
- Tests for bulk adding and bulk resetting keys are modified to check if the contract is paused before performing the respective operation.
- A new test is added to check if only the admin can pause the contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->