### PR TITLE
chore: natspec fixes

### DIFF
--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -117,7 +117,8 @@ contract Bundler is TrustedCaller {
      * @notice Register an fid, multiple signers, and rent storage to an address in a single transaction.
      *
      * @param registration Struct containing registration parameters: to, recovery, deadline, and signature.
-     * @param signers      Array of structs containing signer parameters: keyType, key, metadata, deadline, and signature.
+     * @param signers      Array of structs containing signer parameters: keyType, key, metadataType,
+     *                        metadata, deadline, and signature.
      * @param storageUnits Number of storage units to rent
      *
      */

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -364,7 +364,7 @@ contract IdRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
     /**
      * @notice Transfer the fid owned by the from address to another address that does not
      *         have an fid. Caller must provide two signed Transfer messages: one signed by
-     *         the from address and one signed by the to address.
+     *         the recovery address and one signed by the to address.
      *
      * @param from             The owner address of the fid to transfer.
      * @param to               The address to transfer the fid to.

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -432,7 +432,7 @@ contract KeyRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
         }
 
         // Safety: i and j can be incremented unchecked since they are bound by items.length and
-        // item[i].keys.length respectively.
+        // items[i].keys.length respectively.
         unchecked {
             for (uint256 i = 0; i < items.length; i++) {
                 BulkAddData calldata item = items[i];
@@ -458,7 +458,7 @@ contract KeyRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
         }
 
         // Safety: i and j can be incremented unchecked since they are bound by items.length and
-        // fidKeys[i].length respectively.
+        // items[i].keys.length respectively.
         unchecked {
             for (uint256 i = 0; i < items.length; i++) {
                 BulkResetData calldata item = items[i];
@@ -499,7 +499,7 @@ contract KeyRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
     }
 
     /**
-     * @notice Pause add, remove, and reset.e add, remove, and reset.e registration, transfer, and recovery.
+     * @notice Pause add, remove, and reset.
      *         Must be called by the owner.
      */
     function pause() external onlyOwner {
@@ -507,7 +507,7 @@ contract KeyRegistry is TrustedCaller, Signatures, Pausable, EIP712, Nonces {
     }
 
     /**
-     * @notice Unpause add, remove, and reset.otice Unpause add, remove, and reset.otice Unpause registration, transfer, and recovery.
+     * @notice Unpause add, remove, and reset.
      *         Must be called by the owner.
      */
     function unpause() external onlyOwner {


### PR DESCRIPTION
## Motivation

A few more comment fixes turned up in round 2 of our audit.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on making changes to the documentation and variable names in multiple files.

### Detailed summary:
- In `IdRegistry.sol`, the documentation has been updated to mention the need for a recovery address instead of the from address for transferring the fid.
- In `Bundler.sol`, the documentation for the `signers` parameter has been updated to include the `metadataType` parameter.
- In `KeyRegistry.sol`, the variable names in the for loops have been updated from `item[i]` and `fidKeys[i]` to `items[i]` and `items[i].keys` respectively.
- The `pause` function in `KeyRegistry.sol` now has updated documentation that mentions the pausing of add, remove, and reset operations.
- The `unpause` function in `KeyRegistry.sol` now has updated documentation that mentions the unpausing of add, remove, and reset operations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->