### PR TITLE
fix: Install specific version to prevent builds breaking

### DIFF
--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -11,5 +11,5 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 
 ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
 
-# TODO: Install a specific version so builds don't unexpected break in the future
-RUN foundryup
+# Install a specific version so builds don't unexpected break in the future
+RUN foundryup --version nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70


### PR DESCRIPTION
## Change Summary

Tested locally by running `docker compose up`—ran end-to-end without issue. I also confirmed the build actually happened.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to install a specific version of `foundryup` to avoid unexpected breaks in future builds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->