### PR TITLE
fix: Ensure env var references can be passed via `include` direction of Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,10 @@ x-deployer-defaults: &deployer-defaults
 services:
   l2-anvil:
     <<: *anvil-defaults
-    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$L2_MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--retries', '3', '--timeout', '10000']
+    command: |
+      sh -c '
+        exec anvil --host 0.0.0.0 --port ${PORT:-8545} --rpc-url $$L2_MAINNET_RPC_URL --state /var/lib/anvil/state --retries 3 --timeout 10000
+      '
     environment:
       - L2_MAINNET_RPC_URL
     volumes:
@@ -69,10 +72,13 @@ services:
         cast rpc anvil_autoImpersonateAccount false --rpc-url "$$RPC_URL" > /dev/null
         echo "Deploy complete"
       '
-  
+
   l1-anvil:
     <<: *anvil-defaults
-    command: ['anvil', '--host', '0.0.0.0', '--port', '${PORT:-8545}', '--rpc-url', '$L1_MAINNET_RPC_URL', '--state', '/var/lib/anvil/state', '--retries', '3', '--timeout', '10000']
+    command: |
+      sh -c '
+        exec anvil --host 0.0.0.0 --port ${PORT:-8545} --rpc-url $$L1_MAINNET_RPC_URL --state /var/lib/anvil/state --retries 3 --timeout 10000
+      '
     environment:
       - L1_MAINNET_RPC_URL
     volumes:
@@ -80,7 +86,7 @@ services:
       - l1-anvil-cache:/root/.foundry/cache
     ports:
       - '${PORT:-8546}:${PORT:-8545}'
-  
+
   l1-deployer:
     <<: *deployer-defaults
     depends_on:


### PR DESCRIPTION
## Motivation

This allows us to pass them via environment variables, otherwise we get errors saying they aren't defined when including this Docker Compose configuration in another Docker Compose file.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the command in the docker-compose.yml file for the `l2-anvil` and `l1-anvil` services to use a shell script instead of a list of arguments.

### Detailed summary
- Updated the command for the `l2-anvil` service in docker-compose.yml to use a shell script.
- Updated the command for the `l1-anvil` service in docker-compose.yml to use a shell script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->