### PR TITLE
fix: fix fuzz assume

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,7 @@ libs = ["node_modules", "lib"]
 
 [profile.ci]
 verbosity = 3
-fuzz = { runs = 1500 }
+fuzz = { runs = 2500 }
 no_match_path = ""
 match_path = "test/*/**"
 

--- a/test/KeyRegistry/KeyRegistry.integration.t.sol
+++ b/test/KeyRegistry/KeyRegistry.integration.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
+import "forge-std/console.sol";
+
 import {KeyRegistry, IKeyRegistry} from "../../src/KeyRegistry.sol";
 import {IMetadataValidator} from "../../src/interfaces/IMetadataValidator.sol";
 import {SignedKeyRequestValidator} from "../../src/validators/SignedKeyRequestValidator.sol";
@@ -114,6 +116,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         signerPk = _boundPk(signerPk);
         uint256 deadline = _boundDeadline(_deadline);
         address signer = vm.addr(signerPk);
+        vm.assume(signer != to);
 
         uint256 requestFid = _register(signer);
 
@@ -146,6 +149,7 @@ contract KeyRegistryIntegrationTest is KeyRegistryTestSuite, SignedKeyRequestVal
         uint256 deadline = _boundDeadline(_deadline);
         vm.assume(signerPk != otherPk);
         address signer = vm.addr(signerPk);
+        vm.assume(signer != to);
 
         _registerFid(to, recovery);
         uint256 requestFid = _register(signer);


### PR DESCRIPTION
## Motivation

There's a failing fuzz test on main. It's a false positive: we need to exclude cases where `to` and `signer` are the same address in these tests.

## Change Summary

Add a `vm.assume` to exclude these test runs. Bump test runs back up to 2500 in the CI config.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Increase the number of fuzz runs in the CI profile and add console logging to the KeyRegistry integration test.

### Detailed summary:
- Increased the number of fuzz runs in the CI profile from 1500 to 2500.
- Added console logging to the KeyRegistry integration test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->