### PR TITLE
chore: update license identifiers

### DIFF
--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 import {SignatureChecker} from "openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 import {Nonces} from "openzeppelin-latest/contracts/utils/Nonces.sol";

--- a/src/RecoveryProxy.sol
+++ b/src/RecoveryProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 import {IdRegistry} from "./IdRegistry.sol";

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.21;
 
 import {AggregatorV3Interface} from "chainlink/v0.8/interfaces/AggregatorV3Interface.sol";

--- a/src/interfaces/IIdRegistry.sol
+++ b/src/interfaces/IIdRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 interface IIdRegistry {

--- a/src/interfaces/IdRegistryLike.sol
+++ b/src/interfaces/IdRegistryLike.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.21;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
 
 interface IdRegistryLike {
     function idOf(address fidOwner) external view returns (uint256);

--- a/src/lib/TrustedCaller.sol
+++ b/src/lib/TrustedCaller.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";


### PR DESCRIPTION
## Motivation

A number of files are using the `UNLICENSED` identifier but should be updated with real licenses.

## Change Summary

Update contracts with OZ-only dependencies to `MIT`. Update `StorageRegistry` to `AGPL-3.0-only`, required by Solmate.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.
