### PR TITLE
chore: add v3 deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This repository contains all the contracts deployed by the [Farcaster protocol](
 2. **[Storage Registry](./src/StorageRegistry.sol)** - allocates storage to fids and collects rent.
 3. **[Key Registry](./src/KeyRegistry.sol)** - allows users with an fid to register key pairs for signing messages.
 4. **[Bundler](./src/Bundler.sol)** - allows calling registry and storage in a single transaction.
-5. **[Fname Resolver](./src/FnameResolver.sol)** - validates Farcaster ENS names which were issued off-chain.
+5. **[Signed Key Request Validator](./src/validators/SignedKeyRequestValidator.sol)** - validates key registry metadata.
+6. **[Recovery Proxy](./src/RecoveryProxy.sol)** - proxy for recovery service operators to initiate fid recovery.
+7. **[Fname Resolver](./src/FnameResolver.sol)** - validates Farcaster ENS names which were issued off-chain.
 
 Read the [docs](docs/docs.md) for more details on how the contracts work.
 
@@ -18,13 +20,31 @@ Please see the [contributing guidelines](CONTRIBUTING.md).
 
 ### v3 Contracts
 
-The v3 contracts have not yet been deployed.
+The [v3 contracts](https://github.com/farcasterxyz/contracts/releases/tag/v3.0.0) are deployed on both Optimism mainnet and Ethereum mainnet.
+
+The L2 contracts can be found at the following addresses on Optimism mainnet:
+
+| Contract                  | Address                                                                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| IdRegistry                | [0x00000000fcaf86937e41ba038b4fa40baa4b780a](https://optimistic.etherscan.io/address/0x00000000fcaf86937e41ba038b4fa40baa4b780a) |
+| StorageRegistry           | [0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d](https://optimistic.etherscan.io/address/0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d) |
+| KeyRegistry               | [0x00000000fc9e66f1c6d86d750b4af47ff0cc343d](https://optimistic.etherscan.io/address/0x00000000fc9e66f1c6d86d750b4af47ff0cc343d) |
+| Bundler                   | [0x00000000fc94856f3967b047325f88d47bc225d0](https://optimistic.etherscan.io/address/0x00000000fc94856f3967b047325f88d47bc225d0) |
+| SignedKeyRequestValidator | [0x00000000fc700472606ed4fa22623acf62c60553](https://optimistic.etherscan.io/address/0x00000000fc700472606ed4fa22623acf62c60553) |
+| RecoveryProxy             | [0x00000000fcd5a8e45785c8a4b9a718c9348e4f18](https://optimistic.etherscan.io/address/0x00000000fcd5a8e45785c8a4b9a718c9348e4f18) |
+
+The L1 contract can be found at the following address on Ethereum mainnet:
+
+| Contract                  | Address                                                                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| FnameResolver             | Not yet deployed                                                                                                                 |
+
 
 ### v2 Contracts
 
 The [v2 contracts](https://github.com/farcasterxyz/contracts/releases/tag/v2.0.0) can be found at the following addresses on L1 Goerli:
 
-| Network        | Address                                                                                                                      |
+| Contract       | Address                                                                                                                      |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | IdRegistry     | [0xda107a1caf36d198b12c16c7b6a1d1c795978c42](https://goerli.etherscan.io/address/0xda107a1caf36d198b12c16c7b6a1d1c795978c42) |
 | NameRegistry   | [0xe3be01d99baa8db9905b33a3ca391238234b79d1](https://goerli.etherscan.io/address/0xe3be01d99baa8db9905b33a3ca391238234b79d1) |

--- a/test/Deploy/DeployL2.t.sol
+++ b/test/Deploy/DeployL2.t.sol
@@ -54,7 +54,7 @@ contract DeployL2Test is DeployL2, Test {
     address internal deployer = address(0x6D2b70e39C6bc63763098e336323591eb77Cd0C6);
 
     function setUp() public {
-        vm.createSelectFork("l2_mainnet");
+        vm.createSelectFork("l2_mainnet", 108869038);
 
         (alice, alicePk) = makeAddrAndKey("alice");
         (bob, bobPk) = makeAddrAndKey("bob");


### PR DESCRIPTION
## Change Summary

Add deployed v3 contract addresses.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `setUp` function in `DeployL2.t.sol` now takes an additional parameter `108869038` when calling `vm.createSelectFork`.
- The `Fname Resolver` contract is updated to include a new validator contract called `SignedKeyRequestValidator`.
- The `RecoveryProxy` contract is added.
- Deployment addresses for v3 contracts on both Optimism mainnet and Ethereum mainnet are provided.
- Deployment addresses for v2 contracts on L1 Goerli are provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->