### PR TITLE
chore: Download Foundry binaries directly from download.farcaster.xyz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,41 @@ env:
 
 
 jobs:
+  build-image:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker images defined in Docker Compose file
+        uses: docker/bake-action@v3
+        with:
+          load: true # Load images into local Docker engine after build
+
+      - name: Run containers defined in Docker Compose
+        shell: bash
+        run: docker compose up --detach
+
+      - name: Check that Anvil is running
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 5
+          retry_wait_seconds: 5
+          max_attempts: 3
+          shell: bash
+          command: '[ "$(cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)" = 10000000000000000000000 ]' # Default address
+          on_retry_command: docker compose logs
+
   test:
     strategy:
       fail-fast: true

--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -6,10 +6,15 @@
 
 FROM ubuntu:latest
 
-RUN apt-get update -y && apt-get install -y curl bash git netcat
-RUN curl -L https://foundry.paradigm.xyz | bash
+RUN apt-get update -y && apt-get install -y bash curl git gzip netcat
 
-ENV RUST_BACKTRACE=full PATH="$PATH:/root/.foundry/bin"
+# Foundry only keeps the latest 3 nightly releases available, removing older
+# ones. We host the artifacts ourselves to ensure they are always there.
+#
+# This also makes the build very fast (building from source takes ~10 minutes on an M2 Max)
+ARG TARGETARCH COMMIT_HASH=577dae3f632b392856d1d62a5016c765fadd872d
+RUN curl --proto '=https' --tlsv1.2 -sSf \
+  "https://download.farcaster.xyz/foundry/foundry_${COMMIT_HASH}_linux_${TARGETARCH}.tar.gz" \
+  | tar -xzf - -C /usr/local/bin
 
-# Install a specific version so builds don't unexpected break in the future
-RUN foundryup --version nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70
+ENV RUST_BACKTRACE=full


### PR DESCRIPTION
## Motivation

Foundry doesn't keep around old artifacts, so our previous pinning approach had the unintended effect of breaking the build once the artifact was removed.

Since we are pinning to avoid unexpected breakages in later versions of Foundry's toolchain, pin to a build artifact that is known to work (downloaded from GitHub Sept 3, 2023 UTC).

While here, add a test to ensure the image works.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the CI workflow and optimizing the Docker image build process.

### Detailed summary
- Added a new job "build-image" with necessary steps for building Docker images.
- Updated the Dockerfile to install additional dependencies and download Foundry artifacts from a custom source.
- Removed the installation of a specific version of Foundry to avoid unexpected breaks in the future.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->