### PR TITLE
Documentation: Add ContractReader.io links for contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ The [v3 contracts](https://github.com/farcasterxyz/contracts/releases/tag/v3.0.0
 
 ### OP Mainnet
 
-| Contract                  | Address                                                                                                                          |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| IdRegistry                | [0x00000000fcaf86937e41ba038b4fa40baa4b780a](https://optimistic.etherscan.io/address/0x00000000fcaf86937e41ba038b4fa40baa4b780a) |
-| StorageRegistry           | [0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d](https://optimistic.etherscan.io/address/0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d) |
-| KeyRegistry               | [0x00000000fc9e66f1c6d86d750b4af47ff0cc343d](https://optimistic.etherscan.io/address/0x00000000fc9e66f1c6d86d750b4af47ff0cc343d) |
-| Bundler                   | [0x00000000fc94856f3967b047325f88d47bc225d0](https://optimistic.etherscan.io/address/0x00000000fc94856f3967b047325f88d47bc225d0) |
-| SignedKeyRequestValidator | [0x00000000fc700472606ed4fa22623acf62c60553](https://optimistic.etherscan.io/address/0x00000000fc700472606ed4fa22623acf62c60553) |
-| RecoveryProxy             | [0x00000000fcd5a8e45785c8a4b9a718c9348e4f18](https://optimistic.etherscan.io/address/0x00000000fcd5a8e45785c8a4b9a718c9348e4f18) |
+| Contract                  | Address (Etherscan)                                                                                                              | ContractReader.io
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------
+| IdRegistry                | [0x00000000fcaf86937e41ba038b4fa40baa4b780a](https://optimistic.etherscan.io/address/0x00000000fcaf86937e41ba038b4fa40baa4b780a) | 
+ [0x00000000fcaf86937e41ba038b4fa40baa4b780a](https://www.contractreader.io/contract/optimism/0x00000000fcaf86937e41ba038b4fa40baa4b780a) |
+| StorageRegistry           | [0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d](https://optimistic.etherscan.io/address/0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d) | [0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d](https://www.contractreader.io/contract/optimism/0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d) |
+| KeyRegistry               | [0x00000000fc9e66f1c6d86d750b4af47ff0cc343d](https://optimistic.etherscan.io/address/0x00000000fc9e66f1c6d86d750b4af47ff0cc343d) | [0x00000000fc9e66f1c6d86d750b4af47ff0cc343d](https://www.contractreader.io/contract/optimism/0x00000000fc9e66f1c6d86d750b4af47ff0cc343d) |
+| Bundler                   | [0x00000000fc94856f3967b047325f88d47bc225d0](https://optimistic.etherscan.io/address/0x00000000fc94856f3967b047325f88d47bc225d0) | [0x00000000fc94856f3967b047325f88d47bc225d0](https://www.contractreader.io/contract/optimism/0x00000000fc94856f3967b047325f88d47bc225d0) |
+| SignedKeyRequestValidator | [0x00000000fc700472606ed4fa22623acf62c60553](https://optimistic.etherscan.io/address/0x00000000fc700472606ed4fa22623acf62c60553) | [0x00000000fc700472606ed4fa22623acf62c60553](https://www.contractreader.io/contract/optimism/0x00000000fc700472606ed4fa22623acf62c60553) |
+| RecoveryProxy             | [0x00000000fcd5a8e45785c8a4b9a718c9348e4f18](https://optimistic.etherscan.io/address/0x00000000fcd5a8e45785c8a4b9a718c9348e4f18) | [0x00000000fcd5a8e45785c8a4b9a718c9348e4f18](https://www.contractreader.io/contract/optimism/0x00000000fcd5a8e45785c8a4b9a718c9348e4f18) |
 
 ### ETH Mainnet
 


### PR DESCRIPTION
## Motivation

[ContractReader](https://contractreader.io) is a better contract reading experience so I thought I'd add links to each contract in the readme. 

CR is my site; I hope this isn't inappropriate. Just want to provide a great experience for those wishing to dig into the Farcaster contracts!

## Change Summary

Just added CR links to the Readme

An example of a CR-rendered Farcaster contract vs Etherscan

![CleanShot 2023-10-16 at 13 06 43@2x](https://github.com/farcasterxyz/contracts/assets/87050725/66a032ba-aec8-46ae-87fb-6e6ee703b378)


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating contract addresses in the README file. 

### Detailed summary:
- Updated contract addresses with links to Etherscan and ContractReader.io for OP Mainnet and ETH Mainnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->