### PR TITLE
fix: Add missing envars and increase default balance in `docker-compose.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           retry_wait_seconds: 5
           max_attempts: 10
           shell: bash
-          command: '[ "$(cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)" = 1000000000000000000 ]' # Default address
+          command: '[ "$(cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)" = 4096000000000000000000 ]' # Default address
           on_retry_command: docker compose logs && docker compose ps && cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
       - name: Wait for contract to be deployed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       - STORAGE_RENT_OPERATOR_ADDRESS
       - STORAGE_RENT_TREASURER_ADDRESS
       - BUNDLER_TRUSTED_CALLER_ADDRESS
+      - METADATA_VALIDATOR_OWNER_ADDRESS
+      - MIGRATOR_ADDRESS
     entrypoint: |
       sh -c '
         set -e
@@ -68,7 +70,7 @@ services:
         echo "Enabling impersonation"
         cast rpc anvil_autoImpersonateAccount true --rpc-url "$$RPC_URL" > /dev/null
         echo "Funding deployer"
-        cast rpc anvil_setBalance "$$DEPLOYER" 0xde0b6b3a7640000 --rpc-url "$$RPC_URL" > /dev/null
+        cast rpc anvil_setBalance "$$DEPLOYER" 0xde0b6b3a7640000000 --rpc-url "$$RPC_URL" > /dev/null
         echo "Deploying contract"
         forge install
         forge script -v script/DeployL2.s.sol --rpc-url "$$RPC_URL" --unlocked --broadcast --sender "$$DEPLOYER"


### PR DESCRIPTION
## Motivation

In order to reference this Docker Compose configuration in another `docker-compose.yml` and have it be easier to inject environment variables, we need to declare the envars we're expecting.

## Change Summary

Also while here, increase the amount of ETH allocated to make local testing easier.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update the command in the CI workflow and the balance in the docker-compose file.

### Detailed summary:
- Updated the command in the CI workflow to check for a different balance.
- Added new addresses in the docker-compose file.
- Updated the balance in the docker-compose file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->