### PR TITLE
test: add test coverage for KeyRegistry Ownable2Step

### DIFF
--- a/script/LocalDeploy.s.sol
+++ b/script/LocalDeploy.s.sol
@@ -36,16 +36,11 @@ contract LocalDeploy is Script {
 
         vm.startBroadcast();
         (AggregatorV3Interface priceFeed, AggregatorV3Interface uptimeFeed) = _getOrDeployPriceFeeds();
-        IdRegistry idRegistry = new IdRegistry{salt: ID_REGISTRY_CREATE2_SALT}(
-            migrator,
-            initialIdRegistryOwner
+        IdRegistry idRegistry = new IdRegistry{salt: ID_REGISTRY_CREATE2_SALT}(migrator, initialIdRegistryOwner);
+        KeyRegistry keyRegistry = new KeyRegistry{salt: KEY_REGISTRY_CREATE2_SALT}(
+            address(idRegistry), migrator, initialKeyRegistryOwner, 1000
         );
-        KeyRegistry keyRegistry = new KeyRegistry{
-            salt: KEY_REGISTRY_CREATE2_SALT
-        }(address(idRegistry), migrator, initialKeyRegistryOwner, 1000);
-        StorageRegistry storageRegistry = new StorageRegistry{
-            salt: STORAGE_RENT_CREATE2_SALT
-        }(
+        StorageRegistry storageRegistry = new StorageRegistry{salt: STORAGE_RENT_CREATE2_SALT}(
             priceFeed,
             uptimeFeed,
             INITIAL_USD_UNIT_PRICE,

--- a/test/Bundler/Bundler.gas.t.sol
+++ b/test/Bundler/Bundler.gas.t.sol
@@ -20,9 +20,7 @@ contract BundleRegistryGasUsageTest is BundlerTestSuite {
             bytes memory sig = _signRegister(i, account, address(0), type(uint40).max);
             uint256 price = bundler.price(1);
 
-            IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](
-                0
-            );
+            IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](0);
 
             vm.deal(account, 10_000 ether);
             vm.prank(account);

--- a/test/Bundler/Bundler.t.sol
+++ b/test/Bundler/Bundler.t.sol
@@ -41,9 +41,7 @@ contract BundlerTest is BundlerTestSuite {
         uint256 deadline,
         uint256 numSigners
     ) internal returns (IBundler.SignerParams[] memory) {
-        IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](
-            numSigners
-        );
+        IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](numSigners);
         uint256 nonce = keyRegistry.nonces(account);
 
         // The duplication below is ugly but necessary to work around a stack too deep error.

--- a/test/Bundler/BundlerTestSuite.sol
+++ b/test/Bundler/BundlerTestSuite.sol
@@ -22,10 +22,7 @@ abstract contract BundlerTestSuite is IdGatewayTestSuite {
         keyRegistry.setKeyGateway(address(keyGateway));
 
         // Set up the BundleRegistry
-        bundler = new Bundler(
-            address(idGateway),
-            address(keyGateway)
-        );
+        bundler = new Bundler(address(idGateway), address(keyGateway));
 
         addKnownContract(address(keyGateway));
         addKnownContract(address(bundler));

--- a/test/IdGateway/IdGatewayTestSuite.sol
+++ b/test/IdGateway/IdGatewayTestSuite.sol
@@ -16,11 +16,7 @@ abstract contract IdGatewayTestSuite is StorageRegistryTestSuite, KeyRegistryTes
     function setUp() public virtual override(StorageRegistryTestSuite, KeyRegistryTestSuite) {
         super.setUp();
 
-        idGateway = new IdGateway(
-            address(idRegistry),
-            address(storageRegistry),
-            owner
-        );
+        idGateway = new IdGateway(address(idRegistry), address(storageRegistry), owner);
 
         vm.startPrank(owner);
         idRegistry.setIdGateway(address(idGateway));

--- a/test/KeyRegistry/KeyRegistryTestHelpers.sol
+++ b/test/KeyRegistry/KeyRegistryTestHelpers.sol
@@ -42,9 +42,7 @@ library BulkAddDataBuilder {
         bytes memory metadata
     ) internal pure returns (KeyRegistry.BulkAddData[] memory) {
         KeyRegistry.BulkAddKey[] memory keys = addData[index].keys;
-        KeyRegistry.BulkAddKey[] memory newKeys = new KeyRegistry.BulkAddKey[](
-            keys.length + 1
-        );
+        KeyRegistry.BulkAddKey[] memory newKeys = new KeyRegistry.BulkAddKey[](keys.length + 1);
 
         for (uint256 i; i < keys.length; i++) {
             newKeys[i] = keys[i];
@@ -65,9 +63,7 @@ library BulkResetDataBuilder {
         KeyRegistry.BulkResetData[] memory resetData,
         uint256 fid
     ) internal pure returns (KeyRegistry.BulkResetData[] memory) {
-        KeyRegistry.BulkResetData[] memory newData = new KeyRegistry.BulkResetData[](
-                resetData.length + 1
-            );
+        KeyRegistry.BulkResetData[] memory newData = new KeyRegistry.BulkResetData[](resetData.length + 1);
         for (uint256 i; i < resetData.length; i++) {
             newData[i] = resetData[i];
         }


### PR DESCRIPTION
## Motivation

As mentioned on issue #262, I added few test cases to have test coverage for Ownable2Step for KeyRegistry contract.
Also formatted some contracts with `forge fmt` along the updates.

## Change Summary

Added test cases for coverage on Ownable2Step for KeyRegistry contract, mainly are fuzz testings on transferring ownership to new owner and revert cases on unauthorized acceptance.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)
