### PR TITLE
fix: Remove deprecation warning from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-build-defaults: &build-defaults
   build:
     dockerfile: Dockerfile.foundry


### PR DESCRIPTION
## Motivation

Newer versions of Docker Compose warn about the `version` property now being deprecated.

## Change Summary

Remove it so the bots are happy.

## Merge Checklist

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `docker-compose.yml` file to set a specific Dockerfile for the build process.

### Detailed summary
- Updated the Dockerfile used for building to `Dockerfile.foundry`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->