### PR TITLE
test: simplify symbolic tests using new halmos cheatcode

### DIFF
--- a/test/abstract/Guardians/Guardians.symbolic.t.sol
+++ b/test/abstract/Guardians/Guardians.symbolic.t.sol
@@ -27,7 +27,7 @@ contract GuardiansSymTest is SymTest, Test {
         y = svm.createAddress("y");
     }
 
-    function check_Invariants(bytes4 selector, address caller) public {
+    function check_Invariants(address caller) public {
         _initState();
         vm.assume(x != owner);
         vm.assume(x != y);
@@ -37,9 +37,12 @@ contract GuardiansSymTest is SymTest, Test {
         bool oldGuardianX = guarded.guardians(x);
         bool oldGuardianY = guarded.guardians(y);
 
+        bytes memory data = svm.createCalldata("GuardiansExample");
+        bytes4 selector = bytes4(data);
+
         // Execute an arbitrary tx
         vm.prank(caller);
-        (bool success,) = address(guarded).call(_calldataFor(selector));
+        (bool success,) = address(guarded).call(data);
         vm.assume(success); // ignore reverting cases
 
         // Record post-state
@@ -103,12 +106,5 @@ contract GuardiansSymTest is SymTest, Test {
             vm.prank(owner);
             guarded.pause();
         }
-    }
-
-    /**
-     * @dev Generates valid calldata for a given function selector.
-     */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
-        return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }

--- a/test/abstract/Migration/Migration.symbolic.t.sol
+++ b/test/abstract/Migration/Migration.symbolic.t.sol
@@ -29,16 +29,19 @@ contract MigrationSymTest is SymTest, Test {
         migration = new MigrationExample(gracePeriod, migrator, owner);
     }
 
-    function check_Invariants(bytes4 selector, address caller) public {
+    function check_Invariants(address caller) public {
         _initState();
 
         // Record pre-state
         uint40 oldMigratedAt = migration.migratedAt();
         address oldMigrator = migration.migrator();
 
+        bytes memory data = svm.createCalldata("MigrationExample");
+        bytes4 selector = bytes4(data);
+
         // Execute an arbitrary tx
         vm.prank(caller);
-        (bool success,) = address(migration).call(_calldataFor(selector));
+        (bool success,) = address(migration).call(data);
         vm.assume(success); // ignore reverting cases
 
         // Record post-state
@@ -107,12 +110,5 @@ contract MigrationSymTest is SymTest, Test {
             vm.prank(migration.migrator());
             migration.migrate();
         }
-    }
-
-    /**
-     * @dev Generates valid calldata for a given function selector.
-     */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
-        return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }


### PR DESCRIPTION
## Motivation

This PR improves symbolic tests using new halmos cheatcode `createCalldata()`.

Previously, symbolic tests required custom calldata generators to handle dynamic-sized arrays and bytes. The new `createCalldata()` cheatcode now seamlessly supports such dynamically-sized parameters by considering all combinations of size candidates. These sizes can be specified using the additional flags `--array-lengths` and `--default-bytes-lengths` (refer to `halmos -h` for more details.)

With this new cheatcode, the symbolic tests are now much simpler to understand and maintain, while also accounting for more combinations of dynamic parameter sizes.

## Change Summary

Replaced the custom calldata generator `_calldataFor()` with the `createCalldata()` cheatcode.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

