### PR TITLE
fix: errors in description lines of the code

### DIFF
--- a/src/IdGateway.sol
+++ b/src/IdGateway.sol
@@ -62,7 +62,7 @@ contract IdGateway is IIdGateway, Guardians, Signatures, EIP712, Nonces {
      *         Set the owner of the contract to the provided _owner.
      *
      * @param _idRegistry      IdRegistry address.
-     * @param _storageRegistry StorageRegistery address.
+     * @param _storageRegistry StorageRegistry address.
      * @param _initialOwner    Initial owner address.
      *
      */

--- a/src/KeyGateway.sol
+++ b/src/KeyGateway.sol
@@ -50,7 +50,7 @@ contract KeyGateway is IKeyGateway, Guardians, Signatures, EIP712, Nonces {
      *         Set the initial owner address.
      *
      * @param _keyRegistry  Address of the KeyRegistry contract.
-     * @param _initialOwner Address of the inital owner.
+     * @param _initialOwner Address of the initial owner.
      */
     constructor(
         address _keyRegistry,

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -87,7 +87,7 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /// @dev Revert if transferred to the zero address.
     error InvalidAddress();
 
-    /// @dev Revert if the caller attempts a continuous credit withan invalid range.
+    /// @dev Revert if the caller attempts a continuous credit with an invalid range.
     error InvalidRangeInput();
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

(https://github.com/farcasterxyz/contracts/blob/main/src/IdGateway.sol)
(https://github.com/farcasterxyz/contracts/blob/main/src/KeyGateway.sol)
(https://github.com/farcasterxyz/contracts/blob/main/src/StorageRegistry.sol)

## Change Summary

StorageRegistery -> StorageRegistry; inital owner -> initial owner; withan -> with an

No functional code changes were made; only the error message text was updated. The change does not affect any logic or functionality, so existing tests (if any) should continue to pass without modification.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

fixes #434

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos and improving documentation clarity in the Solidity files.

### Detailed summary
- In `src/IdGateway.sol`, corrected the spelling of `StorageRegistery` to `StorageRegistry`.
- In `src/KeyGateway.sol`, corrected the spelling of `inital` to `initial`.
- In `src/StorageRegistry.sol`, added a space in the comment for `InvalidRangeInput` error message.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->