### PR TITLE
Switch back to standard runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-image:
     timeout-minutes: 5
-    runs-on: ${{ vars.BUILDJET_DISABLED == 'true' && 'ubuntu-latest' || 'buildjet-16vcpu-ubuntu-2204' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -93,7 +93,7 @@ jobs:
       fail-fast: true
 
     timeout-minutes: 15
-    runs-on: ${{ vars.BUILDJET_DISABLED == 'true' && 'ubuntu-latest' || 'buildjet-16vcpu-ubuntu-2204' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -119,7 +119,7 @@ jobs:
         run: forge snapshot --check --match-contract Gas
 
   halmos:
-    runs-on: ${{ vars.BUILDJET_DISABLED == 'true' && 'macos-latest' || 'buildjet-16vcpu-ubuntu-2204' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -142,7 +142,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ${{ vars.BUILDJET_DISABLED == 'true' && 'ubuntu-latest' || 'buildjet-2vcpu-ubuntu-2204' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Change Summary

Switch to normal runners.

## Merge Checklist

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `runs-on` configuration in the GitHub Actions CI workflow by replacing conditional expressions with a fixed environment, specifically setting all `runs-on` values to `ubuntu-latest`.

### Detailed summary
- Changed `runs-on` from conditional expressions to `ubuntu-latest` in the `build-image` job.
- Updated `runs-on` to `ubuntu-latest` in the second job with a timeout of 15 minutes.
- Modified `runs-on` to `ubuntu-latest` in the `halmos` job.
- Set `runs-on` to `ubuntu-latest` in the last job with specified permissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->