### PR TITLE
Fix broken Farcaster Hubs documentation link

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -347,7 +347,7 @@ The [Fname registry](https://github.com/farcasterxyz/fname-registry) is an offch
 
 # 3.2. Hubs
 
-[Hubs](https://docs.farcaster.xyz/protocol/hubs.html) are offchain servers that store data on behalf of addresses that have registered an fid. They track the IdRegistry to know the addresses that have an fid, the StorageRegistry to find out how many messages they are allowed to store and the KeyRegistry to find out which key pairs can sign messages on behalf of the user.
+[Hubs](https://docs.farcaster.xyz/learn/architecture/hubs) are offchain servers that store data on behalf of addresses that have registered an fid. They track the IdRegistry to know the addresses that have an fid, the StorageRegistry to find out how many messages they are allowed to store and the KeyRegistry to find out which key pairs can sign messages on behalf of the user.
 
 ### Assumptions
 


### PR DESCRIPTION

Fixed broken link to Farcaster Hubs documentation

- [Hubs](https://docs.farcaster.xyz/protocol/hubs.html)
+ [Hubs](https://docs.farcaster.xyz/learn/architecture/hubs)

The old documentation link was outdated and led to a 404 error.