### PR TITLE
Replace incorrect link to Forge in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ max-cache-ttl 100000000
 
 ### 2.3 Style Guide
 
-- `yarn format` uses [forge fmt](https://github.com/foundry-rs/foundry/tree/master/forge) to find and
+- `yarn format` uses [forge fmt](https://github.com/foundry-rs/foundry/tree/master/crates/forge) to find and
   auto-correct formatting issues.
 - `yarn format:check` performs the same checks, but alerts on errors and does not fix them.
 


### PR DESCRIPTION
Replaced the outdated link to Forge with the correct one pointing to the crates directory.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link in the `CONTRIBUTING.md` file to point to the correct location for `forge fmt` within the `foundry` repository.

### Detailed summary
- Updated the link for `yarn format` from `crates/forge` to the correct path in the `foundry` repository.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->