### PR TITLE
docs: Clarify Naming Consistency in Section 1.2

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -45,7 +45,7 @@ graph TD
 
 1. [L2 Contracts](#1-l2-contracts)
    1. [Id Registry](#11-id-registry)
-   2. [Id Gateway](#12-id-manager)
+   2. [Id Manager](#12-id-manager)
    3. [Storage Registry](#13-storage-registry)
    4. [Key Registry](#14-key-registry)
    5. [Key Gateway](#15-key-manager)


### PR DESCRIPTION
## Motivation

<img width="312" alt="Снимок экрана 2024-12-23 в 20 38 15" src="https://github.com/user-attachments/assets/92352c69-f9e5-4504-b73a-dfa6bf4cfdbf" />

While reviewing the documentation, I noticed a potential source of confusion in Section 1.2. The title refers to "Id Gateway," but within the section itself, the term "IdManager" is used repeatedly.

To ensure consistency and clarity for readers, I've updated the section title in the Table of Contents and throughout the document to "IdManager," as this term seems to reflect the intended name.  

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation in `docs/docs.md` to correct the naming of a section related to the ID management system.

### Detailed summary
- Changed the section title from `[Id Gateway](#12-id-manager)` to `[Id Manager](#12-id-manager)` in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->