### PR TITLE
Fix BulkAddKey struct IKeyRegistry.sol

### DIFF
--- a/src/interfaces/IKeyRegistry.sol
+++ b/src/interfaces/IKeyRegistry.sol
@@ -201,7 +201,7 @@ interface IKeyRegistry {
      *      and its associated metadata.
      *
      * @param key  Bytes of the signer key.
-     * @param keys Metadata metadata of the signer key.
+     * @param metadata Metadata of the signer key.
      */
     struct BulkAddKey {
         bytes key;


### PR DESCRIPTION
This pull request fixes a documentation comment where the @param keys descriptor incorrectly referenced the metadata field, leading to duplication of the word “metadata.” The comment is now updated to accurately reflect the parameter name and provide a concise explanation of its purpose.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation for the `BulkAddKey` struct in the `src/interfaces/IKeyRegistry.sol` file to improve clarity regarding the parameters.

### Detailed summary
- Changed the parameter description from `@param keys Metadata metadata of the signer key.` to `@param metadata Metadata of the signer key.` for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->