### PR TITLE
chore: fix typos  IStorageRegistry.sol

### DIFF
--- a/src/interfaces/IStorageRegistry.sol
+++ b/src/interfaces/IStorageRegistry.sol
@@ -190,14 +190,14 @@ interface IStorageRegistry {
     function refreshPrice() external;
 
     /**
-     * @notice Change the price feed addresss. Callable by owner.
+     * @notice Change the price feed address. Callable by owner.
      *
      * @param feed The new price feed.
      */
     function setPriceFeed(AggregatorV3Interface feed) external;
 
     /**
-     * @notice Change the uptime feed addresss. Callable by owner.
+     * @notice Change the uptime feed address. Callable by owner.
      *
      * @param feed The new uptime feed.
      */


### PR DESCRIPTION
## Motivation
Fixing the typo improves readability and avoids confusion.

## Change Summary
Replaced "addresss" with "address" for correct spelling.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typographical errors in the documentation comments of the `setPriceFeed` function in the `IStorageRegistry` interface.

### Detailed summary
- Fixed typo in the comment for `setPriceFeed`: changed "addresss" to "address".
- Fixed typo in the comment for the uptime feed: changed "addresss" to "address".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->