### PR TITLE
Corrected spelling and grammar mistakes

### DIFF
--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -79,7 +79,7 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
     string public constant VERSION = "2023.08.23";
 
     /**
-     * @dev EIP-712 typehash of the UsernameProof struct.
+     * @dev EIP-712 typehash of the UserNameProof struct.
      */
     bytes32 public constant USERNAME_PROOF_TYPEHASH =
         keccak256("UserNameProof(string name,uint256 timestamp,address owner)");


### PR DESCRIPTION
changed made:

UsernameProof - UserNameProof (Changed UsernameProof to UserNameProof to follow proper compound word capitalization in technical contexts, where both "User" and "Name" are significant parts of the term)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating a comment and the typehash definition for a struct in the `src/FnameResolver.sol` file to reflect a change in naming from `UsernameProof` to `UserNameProof`.

### Detailed summary
- Updated the comment to change `UsernameProof` to `UserNameProof`.
- Modified the `bytes32` constant `USERNAME_PROOF_TYPEHASH` to use `UserNameProof` in its definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->