### PR TITLE
fix: optimize state changes order in _unsafeTransfer

### DIFF
--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -241,9 +241,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
      * @dev Transfer the fid to another address without checking invariants.
      */
     function _unsafeTransfer(uint256 id, address from, address to) internal whenNotPaused {
+        delete idOf[from];
         idOf[to] = id;
         custodyOf[id] = to;
-        delete idOf[from];
 
         emit Transfer(from, to, id);
     }


### PR DESCRIPTION
Reorder state changes in _unsafeTransfer function to follow best practices:
1. First clear old state (delete idOf[from])
2. Then set new state (idOf[to] and custodyOf[id])
This change helps prevent potential reentrancy issues and provides clearer state transition.