### PR TITLE
docs: fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,9 @@ A node provider like Alchemy, Infura or Coinbase can be used to deploy the contr
 create a `.env` file with the following secrets:
 
 - `GOERLI_RPC_URL`- get this from your node provider (alchemy/infura)
-- `GOERLI_PRIVATE_KEY` - [export](https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key)
+- `GOERLI_PRIVATE_KEY` - [export](https://support.metamask.io/configure/accounts/how-to-export-an-accounts-private-key/)
   this from a non-critical metamask wallet that has some goerli eth
-- `ETHERSCAN_KEY` - get this from the [etherscan api](https://etherscan.io/myapikey.)
+- `ETHERSCAN_KEY` - get this from the [etherscan api](https://etherscan.io/myapikey)
 
 1. Load the environment variables into your shell with `source .env`
 


### PR DESCRIPTION
## Motivation

The original links to the MetaMask private key export guide and Etherscan API key page were outdated or broken.

## Change Summary

Replaced two outdated URLs with their current valid equivalents in the Goerli deployment section.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

N/A
