### PR TITLE
chore: reformat with latest stable foundry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Install Docker buildx
         uses: docker/setup-buildx-action@v2
@@ -102,7 +102,7 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run forge build
         run: |
@@ -148,6 +148,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
 
       - name: Check code coverage
         run: forge coverage --report summary --report lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install halmos
         run: pip install halmos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: pip install halmos
 
       - name: Run halmos
-        run: halmos --solver-command yices-smt2 --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
+        run: halmos --debug
 
   coverage:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: pip install halmos
 
       - name: Run halmos
-        run: halmos --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
+        run: halmos --solver-command yices-smt2 --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
 
   coverage:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: pip install halmos
 
       - name: Run halmos
-        run: halmos --error-unknown --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
+        run: halmos --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
 
   coverage:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
 
   halmos:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/a16z/halmos:latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -128,15 +130,8 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
-      - name: Install halmos
-        run: pip install halmos
-
       - name: Run halmos
-        run: halmos --debug
+        run: halmos --test-parallel --solver-parallel --storage-layout=generic --solver-timeout-assertion 0
 
   coverage:
     permissions:

--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -8,13 +8,8 @@ FROM ubuntu:latest
 
 RUN apt-get update -y && apt-get install -y bash curl git gzip netcat-openbsd
 
-# Foundry only keeps the latest 3 nightly releases available, removing older
-# ones. We host the artifacts ourselves to ensure they are always there.
-#
-# This also makes the build very fast (building from source takes ~10 minutes on an M2 Max)
-ARG TARGETARCH COMMIT_HASH=577dae3f632b392856d1d62a5016c765fadd872d
-RUN curl --proto '=https' --tlsv1.2 -sSf \
-  "https://download.farcaster.xyz/foundry/foundry_${COMMIT_HASH}_linux_${TARGETARCH}.tar.gz" \
-  | tar -xzf - -C /usr/local/bin
+RUN curl --proto '=https' --tlsv1.2 -L "https://foundry.paradigm.xyz" | bash
+ENV PATH="$PATH:/root/.foundry/bin"
+RUN foundryup --install stable
 
 ENV RUST_BACKTRACE=full

--- a/Dockerfile.foundry
+++ b/Dockerfile.foundry
@@ -6,7 +6,7 @@
 
 FROM ubuntu:latest
 
-RUN apt-get update -y && apt-get install -y bash curl git gzip netcat
+RUN apt-get update -y && apt-get install -y bash curl git gzip netcat-openbsd
 
 # Foundry only keeps the latest 3 nightly releases available, removing older
 # ones. We host the artifacts ourselves to ensure they are always there.

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,6 @@ bytecode_hash = 'none'
 [profile.ci]
 verbosity = 3
 fuzz = { runs = 2500 }
-no_match_path = ""
 match_path = "test/*/**"
 
 [fmt]

--- a/script/DeployL1.s.sol
+++ b/script/DeployL1.s.sol
@@ -22,7 +22,9 @@ contract DeployL1 is ImmutableCreate2Deployer {
         runDeploy(loadDeploymentParams());
     }
 
-    function runDeploy(DeploymentParams memory params) public returns (Contracts memory) {
+    function runDeploy(
+        DeploymentParams memory params
+    ) public returns (Contracts memory) {
         return runDeploy(params, true);
     }
 

--- a/script/DeployL2.s.sol
+++ b/script/DeployL2.s.sol
@@ -75,7 +75,9 @@ contract DeployL2 is ImmutableCreate2Deployer {
         runSetup(runDeploy(loadDeploymentParams()));
     }
 
-    function runDeploy(DeploymentParams memory params) public returns (Contracts memory) {
+    function runDeploy(
+        DeploymentParams memory params
+    ) public returns (Contracts memory) {
         return runDeploy(params, true);
     }
 
@@ -175,7 +177,9 @@ contract DeployL2 is ImmutableCreate2Deployer {
         }
     }
 
-    function runSetup(Contracts memory contracts) public {
+    function runSetup(
+        Contracts memory contracts
+    ) public {
         DeploymentParams memory params = loadDeploymentParams();
         runSetup(contracts, params, true);
     }

--- a/script/LocalDeploy.s.sol
+++ b/script/LocalDeploy.s.sol
@@ -36,16 +36,11 @@ contract LocalDeploy is Script {
 
         vm.startBroadcast();
         (AggregatorV3Interface priceFeed, AggregatorV3Interface uptimeFeed) = _getOrDeployPriceFeeds();
-        IdRegistry idRegistry = new IdRegistry{salt: ID_REGISTRY_CREATE2_SALT}(
-            migrator,
-            initialIdRegistryOwner
+        IdRegistry idRegistry = new IdRegistry{salt: ID_REGISTRY_CREATE2_SALT}(migrator, initialIdRegistryOwner);
+        KeyRegistry keyRegistry = new KeyRegistry{salt: KEY_REGISTRY_CREATE2_SALT}(
+            address(idRegistry), migrator, initialKeyRegistryOwner, 1000
         );
-        KeyRegistry keyRegistry = new KeyRegistry{
-            salt: KEY_REGISTRY_CREATE2_SALT
-        }(address(idRegistry), migrator, initialKeyRegistryOwner, 1000);
-        StorageRegistry storageRegistry = new StorageRegistry{
-            salt: STORAGE_RENT_CREATE2_SALT
-        }(
+        StorageRegistry storageRegistry = new StorageRegistry{salt: STORAGE_RENT_CREATE2_SALT}(
             priceFeed,
             uptimeFeed,
             INITIAL_USD_UNIT_PRICE,

--- a/script/UpgradeL2.s.sol
+++ b/script/UpgradeL2.s.sol
@@ -69,7 +69,9 @@ contract UpgradeL2 is ImmutableCreate2Deployer, Test {
         runSetup(runDeploy(loadDeploymentParams()));
     }
 
-    function runDeploy(DeploymentParams memory params) public returns (Contracts memory) {
+    function runDeploy(
+        DeploymentParams memory params
+    ) public returns (Contracts memory) {
         return runDeploy(params, true);
     }
 
@@ -182,7 +184,9 @@ contract UpgradeL2 is ImmutableCreate2Deployer, Test {
         }
     }
 
-    function runSetup(Contracts memory contracts) public {
+    function runSetup(
+        Contracts memory contracts
+    ) public {
         DeploymentParams memory params = loadDeploymentParams();
         runSetup(contracts, params, true);
     }

--- a/script/abstract/ImmutableCreate2Deployer.sol
+++ b/script/abstract/ImmutableCreate2Deployer.sol
@@ -6,7 +6,9 @@ import "forge-std/console.sol";
 import {Strings} from "openzeppelin/contracts/utils/Strings.sol";
 
 interface ImmutableCreate2Factory {
-    function hasBeenDeployed(address deploymentAddress) external view returns (bool);
+    function hasBeenDeployed(
+        address deploymentAddress
+    ) external view returns (bool);
 
     function findCreate2Address(
         bytes32 salt,
@@ -132,7 +134,9 @@ abstract contract ImmutableCreate2Deployer is Script {
     /**
      * @dev Deploy all registered contracts.
      */
-    function deploy(bool broadcast) internal {
+    function deploy(
+        bool broadcast
+    ) internal {
         console.log(pad("State", 10), pad("Name", 27), pad("Address", 43), "Initcode hash");
         for (uint256 i; i < names.length; i++) {
             _deploy(names[i], broadcast);
@@ -153,7 +157,9 @@ abstract contract ImmutableCreate2Deployer is Script {
         _deploy(name, broadcast);
     }
 
-    function deploy(string memory name) internal {
+    function deploy(
+        string memory name
+    ) internal {
         deploy(name, true);
     }
 

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -57,7 +57,9 @@ contract Bundler is IBundler {
     /**
      * @inheritdoc IBundler
      */
-    function price(uint256 extraStorage) external view returns (uint256) {
+    function price(
+        uint256 extraStorage
+    ) external view returns (uint256) {
         return idGateway.price(extraStorage);
     }
 

--- a/src/FnameResolver.sol
+++ b/src/FnameResolver.sol
@@ -8,7 +8,9 @@ import {ERC165} from "openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {EIP712} from "./abstract/EIP712.sol";
 
 interface IAddressQuery {
-    function addr(bytes32 node) external view returns (address);
+    function addr(
+        bytes32 node
+    ) external view returns (address);
 }
 
 interface IExtendedResolver {
@@ -183,7 +185,9 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
      *
      * @param signer The signer address.
      */
-    function addSigner(address signer) external onlyOwner {
+    function addSigner(
+        address signer
+    ) external onlyOwner {
         signers[signer] = true;
         emit AddSigner(signer);
     }
@@ -193,7 +197,9 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
      *
      * @param signer The signer address.
      */
-    function removeSigner(address signer) external onlyOwner {
+    function removeSigner(
+        address signer
+    ) external onlyOwner {
         signers[signer] = false;
         emit RemoveSigner(signer);
     }
@@ -202,7 +208,9 @@ contract FnameResolver is IExtendedResolver, EIP712, ERC165, Ownable2Step {
                          INTERFACE DETECTION
     //////////////////////////////////////////////////////////////*/
 
-    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view override returns (bool) {
         return interfaceId == type(IExtendedResolver).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/src/IdGateway.sol
+++ b/src/IdGateway.sol
@@ -90,7 +90,9 @@ contract IdGateway is IIdGateway, Guardians, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IIdGateway
      */
-    function price(uint256 extraStorage) external view returns (uint256) {
+    function price(
+        uint256 extraStorage
+    ) external view returns (uint256) {
         return storageRegistry.price(1 + extraStorage);
     }
 
@@ -101,7 +103,9 @@ contract IdGateway is IIdGateway, Guardians, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IIdGateway
      */
-    function register(address recovery) external payable returns (uint256, uint256) {
+    function register(
+        address recovery
+    ) external payable returns (uint256, uint256) {
         return register(recovery, 0);
     }
 
@@ -145,7 +149,9 @@ contract IdGateway is IIdGateway, Guardians, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IIdGateway
      */
-    function setStorageRegistry(address _storageRegistry) external onlyOwner {
+    function setStorageRegistry(
+        address _storageRegistry
+    ) external onlyOwner {
         emit SetStorageRegistry(address(storageRegistry), _storageRegistry);
         storageRegistry = IStorageRegistry(_storageRegistry);
     }

--- a/src/IdRegistry.sol
+++ b/src/IdRegistry.sol
@@ -255,7 +255,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IIdRegistry
      */
-    function changeRecoveryAddress(address recovery) external whenNotPaused {
+    function changeRecoveryAddress(
+        address recovery
+    ) external whenNotPaused {
         /* Revert if the caller does not own an fid */
         uint256 ownerId = idOf[msg.sender];
         if (ownerId == 0) revert HasNoId();
@@ -359,7 +361,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IIdRegistry
      */
-    function setIdGateway(address _idGateway) external onlyOwner {
+    function setIdGateway(
+        address _idGateway
+    ) external onlyOwner {
         if (gatewayFrozen) revert GatewayFrozen();
         emit SetIdGateway(idGateway, _idGateway);
         idGateway = _idGateway;
@@ -378,7 +382,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
                                 MIGRATION
     //////////////////////////////////////////////////////////////*/
 
-    function bulkRegisterIds(BulkRegisterData[] calldata ids) external onlyMigrator {
+    function bulkRegisterIds(
+        BulkRegisterData[] calldata ids
+    ) external onlyMigrator {
         // Safety: i can be incremented unchecked since it is bound by ids.length.
         unchecked {
             for (uint256 i = 0; i < ids.length; i++) {
@@ -403,7 +409,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
         }
     }
 
-    function bulkResetIds(uint24[] calldata ids) external onlyMigrator {
+    function bulkResetIds(
+        uint24[] calldata ids
+    ) external onlyMigrator {
         // Safety: i can be incremented unchecked since it is bound by ids.length.
         unchecked {
             for (uint256 i = 0; i < ids.length; i++) {
@@ -419,7 +427,9 @@ contract IdRegistry is IIdRegistry, Migration, Signatures, EIP712, Nonces {
         }
     }
 
-    function setIdCounter(uint256 _counter) external onlyMigrator {
+    function setIdCounter(
+        uint256 _counter
+    ) external onlyMigrator {
         emit SetIdCounter(idCounter, _counter);
         idCounter = _counter;
     }

--- a/src/KeyRegistry.sol
+++ b/src/KeyRegistry.sol
@@ -194,7 +194,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function remove(bytes calldata key) external whenNotPaused {
+    function remove(
+        bytes calldata key
+    ) external whenNotPaused {
         _remove(_fidOf(msg.sender), key);
     }
 
@@ -218,7 +220,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function bulkAddKeysForMigration(BulkAddData[] calldata items) external onlyMigrator {
+    function bulkAddKeysForMigration(
+        BulkAddData[] calldata items
+    ) external onlyMigrator {
         // Safety: i and j can be incremented unchecked since they are bound by items.length and
         // items[i].keys.length respectively.
         unchecked {
@@ -234,7 +238,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function bulkResetKeysForMigration(BulkResetData[] calldata items) external onlyMigrator {
+    function bulkResetKeysForMigration(
+        BulkResetData[] calldata items
+    ) external onlyMigrator {
         // Safety: i and j can be incremented unchecked since they are bound by items.length and
         // items[i].keys.length respectively.
         unchecked {
@@ -264,7 +270,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function setIdRegistry(address _idRegistry) external onlyOwner {
+    function setIdRegistry(
+        address _idRegistry
+    ) external onlyOwner {
         emit SetIdRegistry(address(idRegistry), _idRegistry);
         idRegistry = IdRegistryLike(_idRegistry);
     }
@@ -272,7 +280,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function setKeyGateway(address _keyGateway) external onlyOwner {
+    function setKeyGateway(
+        address _keyGateway
+    ) external onlyOwner {
         if (gatewayFrozen) revert GatewayFrozen();
         emit SetKeyGateway(keyGateway, _keyGateway);
         keyGateway = _keyGateway;
@@ -290,7 +300,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
     /**
      * @inheritdoc IKeyRegistry
      */
-    function setMaxKeysPerFid(uint256 _maxKeysPerFid) external onlyOwner {
+    function setMaxKeysPerFid(
+        uint256 _maxKeysPerFid
+    ) external onlyOwner {
         if (_maxKeysPerFid <= maxKeysPerFid) revert InvalidMaxKeys();
         emit SetMaxKeysPerFid(maxKeysPerFid, _maxKeysPerFid);
         maxKeysPerFid = _maxKeysPerFid;
@@ -376,7 +388,9 @@ contract KeyRegistry is IKeyRegistry, Migration, Signatures, EIP712, Nonces {
                            FID HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    function _fidOf(address fidOwner) internal view returns (uint256 fid) {
+    function _fidOf(
+        address fidOwner
+    ) internal view returns (uint256 fid) {
         fid = idRegistry.idOf(fidOwner);
         if (fid == 0) revert Unauthorized();
     }

--- a/src/RecoveryProxy.sol
+++ b/src/RecoveryProxy.sol
@@ -76,7 +76,9 @@ contract RecoveryProxy is Ownable2Step {
      *
      * @param _idRegistry IDRegistry contract address.
      */
-    function setIdRegistry(IIdRegistry _idRegistry) external onlyOwner {
+    function setIdRegistry(
+        IIdRegistry _idRegistry
+    ) external onlyOwner {
         emit SetIdRegistry(idRegistry, _idRegistry);
         idRegistry = _idRegistry;
     }

--- a/src/StorageRegistry.sol
+++ b/src/StorageRegistry.sol
@@ -501,7 +501,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function price(uint256 units) public view returns (uint256) {
+    function price(
+        uint256 units
+    ) public view returns (uint256) {
         uint256 ethPrice;
         if (fixedEthUsdPrice != 0) {
             ethPrice = fixedEthUsdPrice;
@@ -618,7 +620,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @dev Calculate the cost in wei to rent storage units.
      */
-    function _price(uint256 units) internal returns (uint256) {
+    function _price(
+        uint256 units
+    ) internal returns (uint256) {
         return _price(units, usdUnitPrice, _ethUsdPrice());
     }
 
@@ -697,7 +701,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setPriceFeed(AggregatorV3Interface feed) external onlyOwner {
+    function setPriceFeed(
+        AggregatorV3Interface feed
+    ) external onlyOwner {
         emit SetPriceFeed(address(priceFeed), address(feed));
         priceFeed = feed;
     }
@@ -705,7 +711,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setUptimeFeed(AggregatorV3Interface feed) external onlyOwner {
+    function setUptimeFeed(
+        AggregatorV3Interface feed
+    ) external onlyOwner {
         emit SetUptimeFeed(address(uptimeFeed), address(feed));
         uptimeFeed = feed;
     }
@@ -713,7 +721,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setPrice(uint256 usdPrice) external onlyOwner {
+    function setPrice(
+        uint256 usdPrice
+    ) external onlyOwner {
         emit SetPrice(usdUnitPrice, usdPrice);
         usdUnitPrice = usdPrice;
     }
@@ -721,7 +731,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setFixedEthUsdPrice(uint256 fixedPrice) external onlyOwner {
+    function setFixedEthUsdPrice(
+        uint256 fixedPrice
+    ) external onlyOwner {
         if (fixedPrice != 0) {
             if (fixedPrice < priceFeedMinAnswer || fixedPrice > priceFeedMaxAnswer) revert InvalidFixedPrice();
         }
@@ -732,7 +744,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setMaxUnits(uint256 max) external onlyOwner {
+    function setMaxUnits(
+        uint256 max
+    ) external onlyOwner {
         emit SetMaxUnits(maxUnits, max);
         maxUnits = max;
     }
@@ -740,7 +754,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setDeprecationTimestamp(uint256 timestamp) external onlyOwner {
+    function setDeprecationTimestamp(
+        uint256 timestamp
+    ) external onlyOwner {
         if (timestamp < block.timestamp) revert InvalidDeprecationTimestamp();
         emit SetDeprecationTimestamp(deprecationTimestamp, timestamp);
         deprecationTimestamp = timestamp;
@@ -749,7 +765,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setCacheDuration(uint256 duration) external onlyOwner {
+    function setCacheDuration(
+        uint256 duration
+    ) external onlyOwner {
         emit SetCacheDuration(priceFeedCacheDuration, duration);
         priceFeedCacheDuration = duration;
     }
@@ -757,7 +775,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setMaxAge(uint256 age) external onlyOwner {
+    function setMaxAge(
+        uint256 age
+    ) external onlyOwner {
         emit SetMaxAge(priceFeedMaxAge, age);
         priceFeedMaxAge = age;
     }
@@ -765,7 +785,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setMinAnswer(uint256 minPrice) external onlyOwner {
+    function setMinAnswer(
+        uint256 minPrice
+    ) external onlyOwner {
         if (minPrice >= priceFeedMaxAnswer) revert InvalidMinAnswer();
         emit SetMinAnswer(priceFeedMinAnswer, minPrice);
         priceFeedMinAnswer = minPrice;
@@ -774,7 +796,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setMaxAnswer(uint256 maxPrice) external onlyOwner {
+    function setMaxAnswer(
+        uint256 maxPrice
+    ) external onlyOwner {
         if (maxPrice <= priceFeedMinAnswer) revert InvalidMaxAnswer();
         emit SetMaxAnswer(priceFeedMaxAnswer, maxPrice);
         priceFeedMaxAnswer = maxPrice;
@@ -783,7 +807,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setGracePeriod(uint256 period) external onlyOwner {
+    function setGracePeriod(
+        uint256 period
+    ) external onlyOwner {
         emit SetGracePeriod(uptimeFeedGracePeriod, period);
         uptimeFeedGracePeriod = period;
     }
@@ -791,7 +817,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function setVault(address vaultAddr) external onlyOwner {
+    function setVault(
+        address vaultAddr
+    ) external onlyOwner {
         if (vaultAddr == address(0)) revert InvalidAddress();
         emit SetVault(vault, vaultAddr);
         vault = vaultAddr;
@@ -800,7 +828,9 @@ contract StorageRegistry is IStorageRegistry, AccessControlEnumerable, Pausable 
     /**
      * @inheritdoc IStorageRegistry
      */
-    function withdraw(uint256 amount) external onlyTreasurer {
+    function withdraw(
+        uint256 amount
+    ) external onlyTreasurer {
         emit Withdraw(vault, amount);
         vault.sendNative(amount);
     }

--- a/src/abstract/EIP712.sol
+++ b/src/abstract/EIP712.sol
@@ -22,7 +22,9 @@ abstract contract EIP712 is IEIP712, EIP712Base {
     /**
      * @inheritdoc IEIP712
      */
-    function hashTypedDataV4(bytes32 structHash) external view returns (bytes32) {
+    function hashTypedDataV4(
+        bytes32 structHash
+    ) external view returns (bytes32) {
         return _hashTypedDataV4(structHash);
     }
 }

--- a/src/abstract/Guardians.sol
+++ b/src/abstract/Guardians.sol
@@ -36,7 +36,9 @@ abstract contract Guardians is IGuardians, Ownable2Step, Pausable {
      *
      * @param _initialOwner Address of the contract owner.
      */
-    constructor(address _initialOwner) {
+    constructor(
+        address _initialOwner
+    ) {
         _transferOwnership(_initialOwner);
     }
 
@@ -47,7 +49,9 @@ abstract contract Guardians is IGuardians, Ownable2Step, Pausable {
     /**
      * @inheritdoc IGuardians
      */
-    function addGuardian(address guardian) external onlyOwner {
+    function addGuardian(
+        address guardian
+    ) external onlyOwner {
         guardians[guardian] = true;
         emit Add(guardian);
     }
@@ -55,7 +59,9 @@ abstract contract Guardians is IGuardians, Ownable2Step, Pausable {
     /**
      * @inheritdoc IGuardians
      */
-    function removeGuardian(address guardian) external onlyOwner {
+    function removeGuardian(
+        address guardian
+    ) external onlyOwner {
         guardians[guardian] = false;
         emit Remove(guardian);
     }

--- a/src/abstract/Migration.sol
+++ b/src/abstract/Migration.sol
@@ -96,7 +96,9 @@ abstract contract Migration is IMigration, Guardians {
     /**
      * @inheritdoc IMigration
      */
-    function setMigrator(address _migrator) public onlyOwner {
+    function setMigrator(
+        address _migrator
+    ) public onlyOwner {
         if (isMigrated()) revert AlreadyMigrated();
         _requirePaused();
         emit SetMigrator(migrator, _migrator);

--- a/src/interfaces/IBundler.sol
+++ b/src/interfaces/IBundler.sol
@@ -67,7 +67,9 @@ interface IBundler {
      * @return Total price in wei.
      *
      */
-    function price(uint256 extraStorage) external view returns (uint256);
+    function price(
+        uint256 extraStorage
+    ) external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                           REGISTRATION

--- a/src/interfaces/IIdGateway.sol
+++ b/src/interfaces/IIdGateway.sol
@@ -70,7 +70,9 @@ interface IIdGateway {
      *
      * @return Total price in wei.
      */
-    function price(uint256 extraStorage) external view returns (uint256);
+    function price(
+        uint256 extraStorage
+    ) external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                              REGISTRATION LOGIC
@@ -83,7 +85,9 @@ interface IIdGateway {
      *
      * @return fid registered FID.
      */
-    function register(address recovery) external payable returns (uint256 fid, uint256 overpayment);
+    function register(
+        address recovery
+    ) external payable returns (uint256 fid, uint256 overpayment);
 
     /**
      * @notice Register a new Farcaster ID (fid) to the caller and rent additional storage.
@@ -148,5 +152,7 @@ interface IIdGateway {
      *
      * @param _storageRegistry The new StorageREgistry address.
      */
-    function setStorageRegistry(address _storageRegistry) external;
+    function setStorageRegistry(
+        address _storageRegistry
+    ) external;
 }

--- a/src/interfaces/IIdRegistry.sol
+++ b/src/interfaces/IIdRegistry.sol
@@ -187,17 +187,23 @@ interface IIdRegistry {
     /**
      * @notice Maps each address to an fid, or zero if it does not own an fid.
      */
-    function idOf(address owner) external view returns (uint256 fid);
+    function idOf(
+        address owner
+    ) external view returns (uint256 fid);
 
     /**
      * @notice Maps each fid to the address that currently owns it.
      */
-    function custodyOf(uint256 fid) external view returns (address owner);
+    function custodyOf(
+        uint256 fid
+    ) external view returns (address owner);
 
     /**
      * @notice Maps each fid to an address that can initiate a recovery.
      */
-    function recoveryOf(uint256 fid) external view returns (address recovery);
+    function recoveryOf(
+        uint256 fid
+    ) external view returns (address recovery);
 
     /*//////////////////////////////////////////////////////////////
                              TRANSFER LOGIC
@@ -283,7 +289,9 @@ interface IIdRegistry {
      *
      * @param recovery The address which can recover the fid. Set to 0x0 to disable recovery.
      */
-    function changeRecoveryAddress(address recovery) external;
+    function changeRecoveryAddress(
+        address recovery
+    ) external;
 
     /**
      * @notice Change the recovery address of fid owned by the owner. Caller must provide an
@@ -364,7 +372,9 @@ interface IIdRegistry {
      *
      * @param _idGateway The new IdGateway address.
      */
-    function setIdGateway(address _idGateway) external;
+    function setIdGateway(
+        address _idGateway
+    ) external;
 
     /**
      * @notice Permanently freeze the IdGateway address. Only callable by owner.

--- a/src/interfaces/IKeyRegistry.sol
+++ b/src/interfaces/IKeyRegistry.sol
@@ -335,7 +335,9 @@ interface IKeyRegistry {
      *
      * @param key   Bytes of the key to remove.
      */
-    function remove(bytes calldata key) external;
+    function remove(
+        bytes calldata key
+    ) external;
 
     /**
      * @notice Remove a key on behalf of another fid owner, setting the key state to REMOVED.
@@ -374,7 +376,9 @@ interface IKeyRegistry {
      *
      * @param items An array of BulkAddData structs including fid and array of BulkAddKey structs.
      */
-    function bulkAddKeysForMigration(BulkAddData[] calldata items) external;
+    function bulkAddKeysForMigration(
+        BulkAddData[] calldata items
+    ) external;
 
     /**
      * @notice Reset multiple keys as part of the initial migration. Only callable by the contract owner.
@@ -384,7 +388,9 @@ interface IKeyRegistry {
      *
      * @param items   A list of BulkResetData structs including an fid and array of keys.
      */
-    function bulkResetKeysForMigration(BulkResetData[] calldata items) external;
+    function bulkResetKeysForMigration(
+        BulkResetData[] calldata items
+    ) external;
 
     /**
      * @notice Set a metadata validator contract for the given keyType and metadataType. Only callable by owner.
@@ -400,14 +406,18 @@ interface IKeyRegistry {
      *
      * @param _idRegistry The new IdRegistry address.
      */
-    function setIdRegistry(address _idRegistry) external;
+    function setIdRegistry(
+        address _idRegistry
+    ) external;
 
     /**
      * @notice Set the KeyGateway address allowed to add keys. Only callable by owner.
      *
      * @param _keyGateway The new KeyGateway address.
      */
-    function setKeyGateway(address _keyGateway) external;
+    function setKeyGateway(
+        address _keyGateway
+    ) external;
 
     /**
      * @notice Permanently freeze the KeyGateway address. Only callable by owner.
@@ -419,5 +429,7 @@ interface IKeyRegistry {
      *
      * @param _maxKeysPerFid The new max keys per fid.
      */
-    function setMaxKeysPerFid(uint256 _maxKeysPerFid) external;
+    function setMaxKeysPerFid(
+        uint256 _maxKeysPerFid
+    ) external;
 }

--- a/src/interfaces/IStorageRegistry.sol
+++ b/src/interfaces/IStorageRegistry.sol
@@ -153,7 +153,9 @@ interface IStorageRegistry {
      * @param units Number of storage units.
      * @return uint256 cost in wei.
      */
-    function price(uint256 units) external view returns (uint256);
+    function price(
+        uint256 units
+    ) external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                          PERMISSIONED ACTIONS
@@ -194,21 +196,27 @@ interface IStorageRegistry {
      *
      * @param feed The new price feed.
      */
-    function setPriceFeed(AggregatorV3Interface feed) external;
+    function setPriceFeed(
+        AggregatorV3Interface feed
+    ) external;
 
     /**
      * @notice Change the uptime feed addresss. Callable by owner.
      *
      * @param feed The new uptime feed.
      */
-    function setUptimeFeed(AggregatorV3Interface feed) external;
+    function setUptimeFeed(
+        AggregatorV3Interface feed
+    ) external;
 
     /**
      * @notice Change the USD price per storage unit. Callable by owner.
      *
      * @param usdPrice The new unit price in USD. Fixed point value with 8 decimals.
      */
-    function setPrice(uint256 usdPrice) external;
+    function setPrice(
+        uint256 usdPrice
+    ) external;
 
     /**
      * @notice Set the fixed ETH/USD price, disabling the price feed if the value is
@@ -219,56 +227,72 @@ interface IStorageRegistry {
      *                   Setting this value back to zero from a nonzero value will
      *                   re-enable the price feed.
      */
-    function setFixedEthUsdPrice(uint256 fixedPrice) external;
+    function setFixedEthUsdPrice(
+        uint256 fixedPrice
+    ) external;
 
     /**
      * @notice Change the maximum supply of storage units. Only callable by owner.
      *
      * @param max The new maximum supply of storage units.
      */
-    function setMaxUnits(uint256 max) external;
+    function setMaxUnits(
+        uint256 max
+    ) external;
 
     /**
      * @notice Change the deprecationTimestamp. Only callable by owner.
      *
      * @param timestamp The new deprecationTimestamp. Must be at least equal to block.timestamp.
      */
-    function setDeprecationTimestamp(uint256 timestamp) external;
+    function setDeprecationTimestamp(
+        uint256 timestamp
+    ) external;
 
     /**
      * @notice Change the priceFeedCacheDuration. Only callable by owner.
      *
      * @param duration The new priceFeedCacheDuration.
      */
-    function setCacheDuration(uint256 duration) external;
+    function setCacheDuration(
+        uint256 duration
+    ) external;
 
     /**
      * @notice Change the priceFeedMaxAge. Only callable by owner.
      *
      * @param age The new priceFeedMaxAge.
      */
-    function setMaxAge(uint256 age) external;
+    function setMaxAge(
+        uint256 age
+    ) external;
 
     /**
      * @notice Change the priceFeedMinAnswer. Only callable by owner.
      *
      * @param minPrice The new priceFeedMinAnswer. Must be less than current priceFeedMaxAnswer.
      */
-    function setMinAnswer(uint256 minPrice) external;
+    function setMinAnswer(
+        uint256 minPrice
+    ) external;
 
     /**
      * @notice Change the priceFeedMaxAnswer. Only callable by owner.
      *
      * @param maxPrice The new priceFeedMaxAnswer. Must be greater than current priceFeedMinAnswer.
      */
-    function setMaxAnswer(uint256 maxPrice) external;
+    function setMaxAnswer(
+        uint256 maxPrice
+    ) external;
 
     /**
      * @notice Change the uptimeFeedGracePeriod. Only callable by owner.
      *
      * @param period The new uptimeFeedGracePeriod.
      */
-    function setGracePeriod(uint256 period) external;
+    function setGracePeriod(
+        uint256 period
+    ) external;
 
     /**
      * @notice Change the vault address that can receive funds from this contract.
@@ -276,7 +300,9 @@ interface IStorageRegistry {
      *
      * @param vaultAddr The new vault address.
      */
-    function setVault(address vaultAddr) external;
+    function setVault(
+        address vaultAddr
+    ) external;
 
     /**
      * @notice Withdraw a specified amount of ether from the contract balance to the vault.
@@ -284,7 +310,9 @@ interface IStorageRegistry {
      *
      * @param amount The amount of ether to withdraw.
      */
-    function withdraw(uint256 amount) external;
+    function withdraw(
+        uint256 amount
+    ) external;
 
     /**
      * @notice Pause, disabling rentals and credits.

--- a/src/interfaces/IdRegistryLike.sol
+++ b/src/interfaces/IdRegistryLike.sol
@@ -12,7 +12,9 @@ interface IdRegistryLike {
     /**
      * @notice Maps each address to an fid, or zero if it does not own an fid.
      */
-    function idOf(address fidOwner) external view returns (uint256);
+    function idOf(
+        address fidOwner
+    ) external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS

--- a/src/interfaces/abstract/IEIP712.sol
+++ b/src/interfaces/abstract/IEIP712.sol
@@ -20,5 +20,7 @@ interface IEIP712 {
      *
      * @return bytes32 EIP-712 message digest.
      */
-    function hashTypedDataV4(bytes32 structHash) external view returns (bytes32);
+    function hashTypedDataV4(
+        bytes32 structHash
+    ) external view returns (bytes32);
 }

--- a/src/interfaces/abstract/IGuardians.sol
+++ b/src/interfaces/abstract/IGuardians.sol
@@ -36,14 +36,18 @@ interface IGuardians {
      *
      * @param guardian Address of the guardian.
      */
-    function addGuardian(address guardian) external;
+    function addGuardian(
+        address guardian
+    ) external;
 
     /**
      * @notice Remove a guardian. Only callable by owner.
      *
      * @param guardian Address of the guardian.
      */
-    function removeGuardian(address guardian) external;
+    function removeGuardian(
+        address guardian
+    ) external;
 
     /**
      * @notice Pause the contract. Only callable by owner or a guardian.

--- a/src/interfaces/abstract/IMigration.sol
+++ b/src/interfaces/abstract/IMigration.sol
@@ -88,5 +88,7 @@ interface IMigration {
      *
      * @param _migrator Migrator address.
      */
-    function setMigrator(address _migrator) external;
+    function setMigrator(
+        address _migrator
+    ) external;
 }

--- a/src/libraries/EnumerableKeySet.sol
+++ b/src/libraries/EnumerableKeySet.sol
@@ -81,7 +81,9 @@ library EnumerableKeySet {
     /**
      * @dev Returns the number of values in the set. O(1).
      */
-    function length(KeySet storage set) internal view returns (uint256) {
+    function length(
+        KeySet storage set
+    ) internal view returns (uint256) {
         return set._values.length;
     }
 
@@ -107,7 +109,9 @@ library EnumerableKeySet {
      * this function has an unbounded cost, and using it as part of a state-changing function may render the function
      * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
      */
-    function values(KeySet storage set) internal view returns (bytes[] memory) {
+    function values(
+        KeySet storage set
+    ) internal view returns (bytes[] memory) {
         return set._values;
     }
 }

--- a/src/validators/SignedKeyRequestValidator.sol
+++ b/src/validators/SignedKeyRequestValidator.sol
@@ -132,7 +132,9 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
      *
      * @return bytes memory Bytes of ABI-encoded struct.
      */
-    function encodeMetadata(SignedKeyRequestMetadata calldata metadata) external pure returns (bytes memory) {
+    function encodeMetadata(
+        SignedKeyRequestMetadata calldata metadata
+    ) external pure returns (bytes memory) {
         return abi.encode(metadata);
     }
 
@@ -145,7 +147,9 @@ contract SignedKeyRequestValidator is IMetadataValidator, Ownable2Step, EIP712 {
      *
      * @param _idRegistry The new IdRegistry address.
      */
-    function setIdRegistry(address _idRegistry) external onlyOwner {
+    function setIdRegistry(
+        address _idRegistry
+    ) external onlyOwner {
         emit SetIdRegistry(address(idRegistry), _idRegistry);
         idRegistry = IdRegistryLike(_idRegistry);
     }

--- a/test/Bundler/Bundler.gas.t.sol
+++ b/test/Bundler/Bundler.gas.t.sol
@@ -20,9 +20,7 @@ contract BundleRegistryGasUsageTest is BundlerTestSuite {
             bytes memory sig = _signRegister(i, account, address(0), type(uint40).max);
             uint256 price = bundler.price(1);
 
-            IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](
-                0
-            );
+            IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](0);
 
             vm.deal(account, 10_000 ether);
             vm.prank(account);

--- a/test/Bundler/Bundler.t.sol
+++ b/test/Bundler/Bundler.t.sol
@@ -41,9 +41,7 @@ contract BundlerTest is BundlerTestSuite {
         uint256 deadline,
         uint256 numSigners
     ) internal returns (IBundler.SignerParams[] memory) {
-        IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](
-            numSigners
-        );
+        IBundler.SignerParams[] memory signers = new IBundler.SignerParams[](numSigners);
         uint256 nonce = keyRegistry.nonces(account);
 
         // The duplication below is ugly but necessary to work around a stack too deep error.
@@ -64,7 +62,7 @@ contract BundlerTest is BundlerTestSuite {
                     abi.encodePacked("metadata", keccak256(abi.encode(i))),
                     nonce + i,
                     deadline
-                    )
+                )
             });
         }
         return signers;

--- a/test/Bundler/BundlerTestSuite.sol
+++ b/test/Bundler/BundlerTestSuite.sol
@@ -22,10 +22,7 @@ abstract contract BundlerTestSuite is IdGatewayTestSuite {
         keyRegistry.setKeyGateway(address(keyGateway));
 
         // Set up the BundleRegistry
-        bundler = new Bundler(
-            address(idGateway),
-            address(keyGateway)
-        );
+        bundler = new Bundler(address(idGateway), address(keyGateway));
 
         addKnownContract(address(keyGateway));
         addKnownContract(address(bundler));
@@ -38,7 +35,9 @@ abstract contract BundlerTestSuite is IdGatewayTestSuite {
     }
 
     // Assert that a given fname was not registered and the contracts have no registrations
-    function _assertUnsuccessfulRegistration(address account) internal {
+    function _assertUnsuccessfulRegistration(
+        address account
+    ) internal {
         assertEq(idRegistry.idOf(account), 0);
         assertEq(idRegistry.recoveryOf(1), address(0));
     }

--- a/test/FnameResolver/FnameResolver.t.sol
+++ b/test/FnameResolver/FnameResolver.t.sol
@@ -129,7 +129,9 @@ contract FnameResolverTest is FnameResolverTestSuite {
                                  SIGNERS
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOwnerCanAddSigner(address signer) public {
+    function testFuzzOwnerCanAddSigner(
+        address signer
+    ) public {
         vm.expectEmit(true, false, false, false);
         emit AddSigner(signer);
 
@@ -147,7 +149,9 @@ contract FnameResolverTest is FnameResolverTestSuite {
         resolver.addSigner(signer);
     }
 
-    function testFuzzOwnerCanRemoveSigner(address signer) public {
+    function testFuzzOwnerCanRemoveSigner(
+        address signer
+    ) public {
         vm.prank(owner);
         resolver.addSigner(signer);
 
@@ -182,7 +186,9 @@ contract FnameResolverTest is FnameResolverTestSuite {
         assertEq(resolver.supportsInterface(type(IERC165).interfaceId), true);
     }
 
-    function testFuzzInterfaceDetectionUnsupportedInterface(bytes4 interfaceId) public {
+    function testFuzzInterfaceDetectionUnsupportedInterface(
+        bytes4 interfaceId
+    ) public {
         vm.assume(interfaceId != type(IExtendedResolver).interfaceId && interfaceId != type(IERC165).interfaceId);
         assertEq(resolver.supportsInterface(interfaceId), false);
     }

--- a/test/IdGateway/IdGateway.owner.t.sol
+++ b/test/IdGateway/IdGateway.owner.t.sol
@@ -51,7 +51,9 @@ contract IdGatewayOwnerTest is IdGatewayTestSuite {
                             ACCEPT OWNERSHIP
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzAcceptOwnership(address newOwner) public {
+    function testFuzzAcceptOwnership(
+        address newOwner
+    ) public {
         vm.assume(newOwner != owner && newOwner != address(0));
         vm.prank(owner);
         idGateway.transferOwnership(newOwner);
@@ -93,7 +95,9 @@ contract IdGatewayOwnerTest is IdGatewayTestSuite {
         assertEq(idGateway.paused(), true);
     }
 
-    function testFuzzCannotPauseUnlessGuardian(address alice) public {
+    function testFuzzCannotPauseUnlessGuardian(
+        address alice
+    ) public {
         vm.assume(alice != owner && alice != address(0));
         assertEq(idGateway.owner(), owner);
         assertEq(idGateway.paused(), false);
@@ -116,7 +120,9 @@ contract IdGatewayOwnerTest is IdGatewayTestSuite {
         assertEq(idGateway.paused(), false);
     }
 
-    function testFuzzCannotUnpauseUnlessOwner(address alice) public {
+    function testFuzzCannotUnpauseUnlessOwner(
+        address alice
+    ) public {
         vm.assume(alice != owner && alice != address(0));
         assertEq(idGateway.owner(), owner);
 

--- a/test/IdGateway/IdGateway.t.sol
+++ b/test/IdGateway/IdGateway.t.sol
@@ -457,7 +457,9 @@ contract IdGatewayTest is IdGatewayTestSuite {
                         SET STORAGE REGISTRY
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzSetStorageRegistry(address storageRegistry) public {
+    function testFuzzSetStorageRegistry(
+        address storageRegistry
+    ) public {
         address prevStorageRegistry = address(idGateway.storageRegistry());
 
         vm.expectEmit();

--- a/test/IdGateway/IdGatewayTestSuite.sol
+++ b/test/IdGateway/IdGatewayTestSuite.sol
@@ -16,11 +16,7 @@ abstract contract IdGatewayTestSuite is StorageRegistryTestSuite, KeyRegistryTes
     function setUp() public virtual override(StorageRegistryTestSuite, KeyRegistryTestSuite) {
         super.setUp();
 
-        idGateway = new IdGateway(
-            address(idRegistry),
-            address(storageRegistry),
-            owner
-        );
+        idGateway = new IdGateway(address(idRegistry), address(storageRegistry), owner);
 
         vm.startPrank(owner);
         idRegistry.setIdGateway(address(idGateway));
@@ -29,7 +25,9 @@ abstract contract IdGatewayTestSuite is StorageRegistryTestSuite, KeyRegistryTes
         addKnownContract(address(idGateway));
     }
 
-    function _registerTo(address caller) internal returns (uint256 fid) {
+    function _registerTo(
+        address caller
+    ) internal returns (uint256 fid) {
         fid = _registerWithRecovery(caller, address(0));
     }
 

--- a/test/IdRegistry/IdRegistry.migration.t.sol
+++ b/test/IdRegistry/IdRegistry.migration.t.sol
@@ -58,7 +58,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
                              SET MIGRATOR
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOwnerCanSetMigrator(address migrator) public {
+    function testFuzzOwnerCanSetMigrator(
+        address migrator
+    ) public {
         address oldMigrator = idRegistry.migrator();
 
         vm.expectEmit();
@@ -69,7 +71,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.migrator(), migrator);
     }
 
-    function testFuzzSetMigratorRevertsWhenMigrated(address migrator) public {
+    function testFuzzSetMigratorRevertsWhenMigrated(
+        address migrator
+    ) public {
         address oldMigrator = idRegistry.migrator();
 
         vm.prank(oldMigrator);
@@ -82,7 +86,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.migrator(), oldMigrator);
     }
 
-    function testFuzzSetMigratorRevertsWhenUnpaused(address migrator) public {
+    function testFuzzSetMigratorRevertsWhenUnpaused(
+        address migrator
+    ) public {
         address oldMigrator = idRegistry.migrator();
 
         vm.startPrank(owner);
@@ -98,7 +104,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
                                 MIGRATION
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzMigration(uint40 timestamp) public {
+    function testFuzzMigration(
+        uint40 timestamp
+    ) public {
         vm.assume(timestamp != 0);
 
         vm.warp(timestamp);
@@ -111,7 +119,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.migratedAt(), timestamp);
     }
 
-    function testFuzzOnlyMigratorCanMigrate(address caller) public {
+    function testFuzzOnlyMigratorCanMigrate(
+        address caller
+    ) public {
         vm.assume(caller != migrator);
 
         vm.prank(caller);
@@ -122,7 +132,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.migratedAt(), 0);
     }
 
-    function testFuzzCannotMigrateTwice(uint40 timestamp) public {
+    function testFuzzCannotMigrateTwice(
+        uint40 timestamp
+    ) public {
         timestamp = uint40(bound(timestamp, 1, type(uint40).max));
         vm.warp(timestamp);
         vm.prank(migrator);
@@ -141,7 +153,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
                           SET COUNTER
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzSetIdCounter(uint256 idCounter) public {
+    function testFuzzSetIdCounter(
+        uint256 idCounter
+    ) public {
         uint256 prevIdCounter = idRegistry.idCounter();
 
         vm.expectEmit();
@@ -188,7 +202,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.idCounter(), prevIdCounter);
     }
 
-    function testFuzzSetIdCounterUnpausedReverts(uint256 idCounter) public {
+    function testFuzzSetIdCounterUnpausedReverts(
+        uint256 idCounter
+    ) public {
         uint256 prevIdCounter = idRegistry.idCounter();
 
         vm.prank(owner);
@@ -239,7 +255,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         idRegistry.bulkRegisterIds(registerItems);
     }
 
-    function testFuzzBulkRegisterDuringGracePeriod(uint40 _warpForward) public {
+    function testFuzzBulkRegisterDuringGracePeriod(
+        uint40 _warpForward
+    ) public {
         IdRegistry.BulkRegisterData[] memory registerItems = BulkRegisterDataBuilder.empty().addFid(1);
 
         uint256 warpForward = bound(_warpForward, 1, idRegistry.gracePeriod() - 1);
@@ -253,7 +271,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testFuzzBulkRegisterAfterGracePeriodRevertsUnauthorized(uint40 _warpForward) public {
+    function testFuzzBulkRegisterAfterGracePeriodRevertsUnauthorized(
+        uint40 _warpForward
+    ) public {
         IdRegistry.BulkRegisterData[] memory registerItems = BulkRegisterDataBuilder.empty().addFid(1);
 
         uint256 warpForward =
@@ -317,7 +337,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         }
     }
 
-    function testBulkRegisterWithRecoveryEmitsEvent(address recovery) public {
+    function testBulkRegisterWithRecoveryEmitsEvent(
+        address recovery
+    ) public {
         IIdRegistry.BulkRegisterDefaultRecoveryData[] memory registerItems =
             BulkRegisterDefaultRecoveryDataBuilder.empty().addFid(1).addFid(2).addFid(3);
 
@@ -366,7 +388,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testBulkRegisterWithRecoveryCannotReRegister(address recovery) public {
+    function testBulkRegisterWithRecoveryCannotReRegister(
+        address recovery
+    ) public {
         IdRegistry.BulkRegisterDefaultRecoveryData[] memory registerItems =
             BulkRegisterDefaultRecoveryDataBuilder.empty().addFid(1).addFid(2).addFid(3);
 
@@ -377,7 +401,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testBulkRegisterWithRecoveryUnpausedReverts(address recovery) public {
+    function testBulkRegisterWithRecoveryUnpausedReverts(
+        address recovery
+    ) public {
         IdRegistry.BulkRegisterDefaultRecoveryData[] memory registerItems =
             BulkRegisterDefaultRecoveryDataBuilder.empty().addFid(1).addFid(2).addFid(3);
 
@@ -393,7 +419,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
                             BULK RESET
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzBulkResetIds(uint24[] memory _ids) public {
+    function testFuzzBulkResetIds(
+        uint24[] memory _ids
+    ) public {
         vm.assume(_ids.length > 0);
         uint256 len = bound(_ids.length, 1, 100);
 
@@ -442,7 +470,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         idRegistry.bulkResetIds(resetItems);
     }
 
-    function testFuzzBulkResetDuringGracePeriod(uint40 _warpForward) public {
+    function testFuzzBulkResetDuringGracePeriod(
+        uint40 _warpForward
+    ) public {
         IdRegistry.BulkRegisterData[] memory registerItems =
             BulkRegisterDataBuilder.empty().addFid(1).addFid(2).addFid(3);
         uint24[] memory resetItems = new uint24[](3);
@@ -464,7 +494,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testFuzzBulkResetAfterGracePeriodRevertsUnauthorized(uint40 _warpForward) public {
+    function testFuzzBulkResetAfterGracePeriodRevertsUnauthorized(
+        uint40 _warpForward
+    ) public {
         uint24[] memory resetItems = new uint24[](3);
 
         uint256 warpForward =

--- a/test/IdRegistry/IdRegistry.owner.t.sol
+++ b/test/IdRegistry/IdRegistry.owner.t.sol
@@ -53,7 +53,9 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
                             ACCEPT OWNERSHIP
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzAcceptOwnership(address newOwner) public {
+    function testFuzzAcceptOwnership(
+        address newOwner
+    ) public {
         vm.assume(newOwner != owner && newOwner != address(0));
         vm.prank(owner);
         idRegistry.transferOwnership(newOwner);
@@ -93,7 +95,9 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         _pause();
     }
 
-    function testAddRemoveGuardian(address guardian) public {
+    function testAddRemoveGuardian(
+        address guardian
+    ) public {
         assertEq(idRegistry.guardians(guardian), false);
 
         vm.expectEmit();
@@ -113,7 +117,9 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.guardians(guardian), false);
     }
 
-    function testFuzzCannotPauseUnlessGuardian(address alice) public {
+    function testFuzzCannotPauseUnlessGuardian(
+        address alice
+    ) public {
         vm.assume(alice != owner && alice != address(0));
         assertEq(idRegistry.owner(), owner);
         assertEq(idRegistry.paused(), false);
@@ -134,7 +140,9 @@ contract IdRegistryOwnerTest is IdRegistryTestSuite {
         assertEq(idRegistry.paused(), false);
     }
 
-    function testFuzzCannotUnpauseUnlessOwner(address alice) public {
+    function testFuzzCannotUnpauseUnlessOwner(
+        address alice
+    ) public {
         vm.assume(alice != owner && alice != address(0));
         assertEq(idRegistry.owner(), owner);
         _pause();

--- a/test/IdRegistry/IdRegistry.symbolic.t.sol
+++ b/test/IdRegistry/IdRegistry.symbolic.t.sol
@@ -180,7 +180,9 @@ contract IdRegistrySymTest is SymTest, Test {
     /**
      * @dev Generates valid calldata for a given function selector.
      */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
+    function _calldataFor(
+        bytes4 selector
+    ) internal returns (bytes memory) {
         bytes memory args;
         if (selector == idRegistry.transfer.selector) {
             args = abi.encode(svm.createAddress("to"), svm.createUint256("deadline"), svm.createBytes(65, "sig"));

--- a/test/IdRegistry/IdRegistry.t.sol
+++ b/test/IdRegistry/IdRegistry.t.sol
@@ -2591,7 +2591,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
                           SET ID GATEWAY
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzSetIdGateway(address idGateway) public {
+    function testFuzzSetIdGateway(
+        address idGateway
+    ) public {
         address prevIdGateway = idRegistry.idGateway();
 
         vm.expectEmit();
@@ -2611,7 +2613,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         idRegistry.setIdGateway(idGateway);
     }
 
-    function testFuzzFreezeIdGateway(address idGateway) public {
+    function testFuzzFreezeIdGateway(
+        address idGateway
+    ) public {
         assertEq(idRegistry.gatewayFrozen(), false);
 
         vm.prank(owner);
@@ -2626,7 +2630,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         assertEq(idRegistry.gatewayFrozen(), true);
     }
 
-    function testFuzzOnlyOwnerCanFreezeIdGateway(address caller) public {
+    function testFuzzOnlyOwnerCanFreezeIdGateway(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.expectRevert("Ownable: caller is not the owner");
@@ -2634,7 +2640,9 @@ contract IdRegistryTest is IdRegistryTestSuite {
         idRegistry.freezeIdGateway();
     }
 
-    function testFuzzSetIdGatewayRevertsWhenFrozen(address idGateway) public {
+    function testFuzzSetIdGatewayRevertsWhenFrozen(
+        address idGateway
+    ) public {
         assertEq(idRegistry.gatewayFrozen(), false);
 
         vm.prank(owner);

--- a/test/IdRegistry/IdRegistryTestHelpers.sol
+++ b/test/IdRegistry/IdRegistryTestHelpers.sol
@@ -23,11 +23,15 @@ library BulkRegisterDataBuilder {
         return newData;
     }
 
-    function custodyOf(uint24 fid) internal pure returns (address) {
+    function custodyOf(
+        uint24 fid
+    ) internal pure returns (address) {
         return address(uint160(uint256(keccak256(abi.encodePacked(fid)))));
     }
 
-    function recoveryOf(uint24 fid) internal pure returns (address) {
+    function recoveryOf(
+        uint24 fid
+    ) internal pure returns (address) {
         return address(uint160(uint256(keccak256(abi.encodePacked(keccak256(abi.encodePacked(fid)))))));
     }
 }
@@ -51,7 +55,9 @@ library BulkRegisterDefaultRecoveryDataBuilder {
         return newData;
     }
 
-    function custodyOf(uint24 fid) internal pure returns (address) {
+    function custodyOf(
+        uint24 fid
+    ) internal pure returns (address) {
         return address(uint160(uint256(keccak256(abi.encodePacked(fid)))));
     }
 }

--- a/test/IdRegistry/IdRegistryTestSuite.sol
+++ b/test/IdRegistry/IdRegistryTestSuite.sol
@@ -24,7 +24,9 @@ abstract contract IdRegistryTestSuite is TestSuiteSetup {
                               TEST HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    function _register(address caller) internal returns (uint256 fid) {
+    function _register(
+        address caller
+    ) internal returns (uint256 fid) {
         fid = _registerWithRecovery(caller, address(0));
     }
 

--- a/test/KeyGateway/KeyGateway.t.sol
+++ b/test/KeyGateway/KeyGateway.t.sol
@@ -428,7 +428,9 @@ contract KeyGatewayTest is KeyGatewayTestSuite {
                           PAUSE
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOnlyAuthorizedCanPause(address caller) public {
+    function testFuzzOnlyAuthorizedCanPause(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -436,7 +438,9 @@ contract KeyGatewayTest is KeyGatewayTestSuite {
         keyGateway.pause();
     }
 
-    function testFuzzOnlyOwnerCanUnpause(address caller) public {
+    function testFuzzOnlyOwnerCanUnpause(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -454,7 +458,9 @@ contract KeyGatewayTest is KeyGatewayTestSuite {
         assertEq(keyGateway.paused(), false);
     }
 
-    function testFuzzPauseUnpauseGuardian(address caller) public {
+    function testFuzzPauseUnpauseGuardian(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(owner);

--- a/test/KeyRegistry/KeyRegistry.migration.t.sol
+++ b/test/KeyRegistry/KeyRegistry.migration.t.sol
@@ -55,7 +55,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                              SET MIGRATOR
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOwnerCanSetMigrator(address migrator) public {
+    function testFuzzOwnerCanSetMigrator(
+        address migrator
+    ) public {
         address oldMigrator = keyRegistry.migrator();
 
         vm.expectEmit();
@@ -66,7 +68,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(keyRegistry.migrator(), migrator);
     }
 
-    function testFuzzSetMigratorRevertsWhenMigrated(address migrator) public {
+    function testFuzzSetMigratorRevertsWhenMigrated(
+        address migrator
+    ) public {
         address oldMigrator = keyRegistry.migrator();
 
         vm.prank(oldMigrator);
@@ -79,7 +83,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(keyRegistry.migrator(), oldMigrator);
     }
 
-    function testFuzzSetMigratorRevertsWhenUnpaused(address migrator) public {
+    function testFuzzSetMigratorRevertsWhenUnpaused(
+        address migrator
+    ) public {
         address oldMigrator = keyRegistry.migrator();
 
         vm.startPrank(owner);
@@ -95,7 +101,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                                 MIGRATION
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzMigration(uint40 timestamp) public {
+    function testFuzzMigration(
+        uint40 timestamp
+    ) public {
         vm.assume(timestamp != 0);
 
         vm.warp(timestamp);
@@ -108,7 +116,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(keyRegistry.migratedAt(), timestamp);
     }
 
-    function testFuzzOnlyMigratorCanMigrate(address caller) public {
+    function testFuzzOnlyMigratorCanMigrate(
+        address caller
+    ) public {
         vm.assume(caller != migrator);
 
         vm.prank(caller);
@@ -119,7 +129,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(keyRegistry.migratedAt(), 0);
     }
 
-    function testFuzzCannotMigrateTwice(uint40 timestamp) public {
+    function testFuzzCannotMigrateTwice(
+        uint40 timestamp
+    ) public {
         timestamp = uint40(bound(timestamp, 1, type(uint40).max));
         vm.warp(timestamp);
         vm.prank(migrator);
@@ -186,7 +198,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.bulkAddKeysForMigration(addItems);
     }
 
-    function testFuzzBulkAddKeyForMigrationDuringGracePeriod(uint40 _warpForward) public {
+    function testFuzzBulkAddKeyForMigrationDuringGracePeriod(
+        uint40 _warpForward
+    ) public {
         _registerValidator(1, 1);
 
         KeyRegistry.BulkAddData[] memory addItems = BulkAddDataBuilder.empty().addFid(1).addKey(0, "key1", "metadata1");
@@ -203,7 +217,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testFuzzBulkAddSignerForMigrationAfterGracePeriodRevertsUnauthorized(uint40 _warpForward) public {
+    function testFuzzBulkAddSignerForMigrationAfterGracePeriodRevertsUnauthorized(
+        uint40 _warpForward
+    ) public {
         KeyRegistry.BulkAddData[] memory addItems = BulkAddDataBuilder.empty().addFid(1).addKey(0, "key1", "metadata1");
 
         uint256 warpForward =
@@ -364,7 +380,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testFuzzBulkRemoveSignerForMigrationDuringGracePeriod(uint40 _warpForward) public {
+    function testFuzzBulkRemoveSignerForMigrationDuringGracePeriod(
+        uint40 _warpForward
+    ) public {
         _registerValidator(1, 1);
 
         KeyRegistry.BulkAddData[] memory addItems = BulkAddDataBuilder.empty().addFid(1).addKey(0, "key", "metadata");
@@ -384,7 +402,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         vm.stopPrank();
     }
 
-    function testFuzzBulkRemoveSignerForMigrationAfterGracePeriodRevertsUnauthorized(uint40 _warpForward) public {
+    function testFuzzBulkRemoveSignerForMigrationAfterGracePeriodRevertsUnauthorized(
+        uint40 _warpForward
+    ) public {
         KeyRegistry.BulkResetData[] memory items = BulkResetDataBuilder.empty().addFid(1).addKey(0, "key");
 
         uint256 warpForward =

--- a/test/KeyRegistry/KeyRegistry.symbolic.t.sol
+++ b/test/KeyRegistry/KeyRegistry.symbolic.t.sol
@@ -171,7 +171,9 @@ contract KeyRegistrySymTest is SymTest, Test {
     }
 
     // Case-splitting tactic: explicitly branching into two states: cond vs !cond
-    function split_cases(bool cond) internal pure {
+    function split_cases(
+        bool cond
+    ) internal pure {
         if (cond) return;
     }
 

--- a/test/KeyRegistry/KeyRegistry.t.sol
+++ b/test/KeyRegistry/KeyRegistry.t.sol
@@ -618,7 +618,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                            PAUSABILITY
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOnlyAdminCanPause(address caller) public {
+    function testFuzzOnlyAdminCanPause(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -652,7 +654,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.setIdRegistry(idRegistry);
     }
 
-    function testFuzzSetIdRegistry(address idRegistry) public {
+    function testFuzzSetIdRegistry(
+        address idRegistry
+    ) public {
         address currentIdRegistry = address(keyRegistry.idRegistry());
 
         vm.expectEmit(false, false, false, true);
@@ -724,7 +728,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.setMaxKeysPerFid(newMax);
     }
 
-    function testFuzzSetMaxKeysPerFid(uint256 newMax) public {
+    function testFuzzSetMaxKeysPerFid(
+        uint256 newMax
+    ) public {
         uint256 currentMax = keyRegistry.maxKeysPerFid();
         newMax = bound(newMax, currentMax + 1, type(uint256).max);
 
@@ -737,7 +743,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(keyRegistry.maxKeysPerFid(), newMax);
     }
 
-    function testFuzzSetMaxKeysPerFidRevertsLessThanOrEqualToCurrentMax(uint256 newMax) public {
+    function testFuzzSetMaxKeysPerFidRevertsLessThanOrEqualToCurrentMax(
+        uint256 newMax
+    ) public {
         uint256 currentMax = keyRegistry.maxKeysPerFid();
         newMax = bound(newMax, 0, currentMax);
 
@@ -760,7 +768,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.setKeyGateway(keyGateway);
     }
 
-    function testFuzzSetKeyGateway(address keyGateway) public {
+    function testFuzzSetKeyGateway(
+        address keyGateway
+    ) public {
         address currentKeyGateway = address(keyRegistry.keyGateway());
 
         vm.expectEmit(false, false, false, true);
@@ -772,7 +782,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         assertEq(address(keyRegistry.keyGateway()), keyGateway);
     }
 
-    function testFuzzSetKeyGatewayRevertsWhenFrozen(address keyGateway) public {
+    function testFuzzSetKeyGatewayRevertsWhenFrozen(
+        address keyGateway
+    ) public {
         address currentKeyGateway = address(keyRegistry.keyGateway());
 
         vm.prank(owner);
@@ -794,7 +806,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
         keyRegistry.freezeKeyGateway();
     }
 
-    function testOnlyOwnerCanFreezeKeyGateway(address caller) public {
+    function testOnlyOwnerCanFreezeKeyGateway(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -1108,7 +1122,9 @@ contract KeyRegistryTest is KeyRegistryTestSuite {
                                  HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    function _makeKey(uint256 i) internal pure returns (bytes memory key, bytes memory metadata) {
+    function _makeKey(
+        uint256 i
+    ) internal pure returns (bytes memory key, bytes memory metadata) {
         key = abi.encodePacked(keccak256(abi.encodePacked("key", i)));
         metadata = abi.encodePacked(keccak256(abi.encodePacked("metadata", i)));
     }

--- a/test/KeyRegistry/KeyRegistryTestHelpers.sol
+++ b/test/KeyRegistry/KeyRegistryTestHelpers.sol
@@ -42,9 +42,7 @@ library BulkAddDataBuilder {
         bytes memory metadata
     ) internal pure returns (KeyRegistry.BulkAddData[] memory) {
         KeyRegistry.BulkAddKey[] memory keys = addData[index].keys;
-        KeyRegistry.BulkAddKey[] memory newKeys = new KeyRegistry.BulkAddKey[](
-            keys.length + 1
-        );
+        KeyRegistry.BulkAddKey[] memory newKeys = new KeyRegistry.BulkAddKey[](keys.length + 1);
 
         for (uint256 i; i < keys.length; i++) {
             newKeys[i] = keys[i];
@@ -65,9 +63,7 @@ library BulkResetDataBuilder {
         KeyRegistry.BulkResetData[] memory resetData,
         uint256 fid
     ) internal pure returns (KeyRegistry.BulkResetData[] memory) {
-        KeyRegistry.BulkResetData[] memory newData = new KeyRegistry.BulkResetData[](
-                resetData.length + 1
-            );
+        KeyRegistry.BulkResetData[] memory newData = new KeyRegistry.BulkResetData[](resetData.length + 1);
         for (uint256 i; i < resetData.length; i++) {
             newData[i] = resetData[i];
         }

--- a/test/RecoveryProxy/RecoveryProxy.t.sol
+++ b/test/RecoveryProxy/RecoveryProxy.t.sol
@@ -106,7 +106,9 @@ contract RecoveryProxyTest is RecoveryProxyTestSuite {
         recoveryProxy.setIdRegistry(_idRegistry);
     }
 
-    function testFuzzSetIdRegistry(IIdRegistry newIdRegistry) public {
+    function testFuzzSetIdRegistry(
+        IIdRegistry newIdRegistry
+    ) public {
         IIdRegistry currentIdRegistry = recoveryProxy.idRegistry();
 
         vm.expectEmit(false, false, false, true);

--- a/test/StorageRegistry/StorageRegistry.t.sol
+++ b/test/StorageRegistry/StorageRegistry.t.sol
@@ -112,7 +112,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.uptimeFeedGracePeriod(), INITIAL_UPTIME_FEED_GRACE_PERIOD);
     }
 
-    function testFuzzInitialPrice(uint128 quantity) public {
+    function testFuzzInitialPrice(
+        uint128 quantity
+    ) public {
         assertEq(storageRegistry.price(quantity), INITIAL_PRICE_IN_ETH * quantity);
     }
 
@@ -992,7 +994,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
                                PRICE FEED
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzPriceFeedRevertsInvalidPrice(int256 price) public {
+    function testFuzzPriceFeedRevertsInvalidPrice(
+        int256 price
+    ) public {
         // Ensure price is zero or negative
         price = price > 0 ? -price : price;
         priceFeed.setPrice(price);
@@ -1035,7 +1039,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.refreshPrice();
     }
 
-    function testFuzzPriceFeedRevertsAnswerBelowBound(uint256 delta) public {
+    function testFuzzPriceFeedRevertsAnswerBelowBound(
+        uint256 delta
+    ) public {
         delta = bound(delta, 1, uint256(storageRegistry.priceFeedMinAnswer()) - 1);
 
         priceFeed.setRoundData(
@@ -1053,7 +1059,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.refreshPrice();
     }
 
-    function testPriceFeedRevertsAnswerAboveBound(uint256 delta) public {
+    function testPriceFeedRevertsAnswerAboveBound(
+        uint256 delta
+    ) public {
         delta = bound(delta, 1, uint256(type(int256).max) - storageRegistry.priceFeedMaxAnswer());
 
         priceFeed.setRoundData(
@@ -1154,7 +1162,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
                                UPTIME FEED
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzUptimeFeedRevertsSequencerDown(int256 answer) public {
+    function testFuzzUptimeFeedRevertsSequencerDown(
+        int256 answer
+    ) public {
         if (answer == 0) ++answer;
         // Set nonzero answer. It's counterintuitive, but a zero answer
         // means the sequencer is up.
@@ -1190,7 +1200,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.refreshPrice();
     }
 
-    function testFuzzUptimeFeedRevertsInvalidTimestamp(uint256 secondsAhead) public {
+    function testFuzzUptimeFeedRevertsInvalidTimestamp(
+        uint256 secondsAhead
+    ) public {
         secondsAhead = bound(secondsAhead, 1, type(uint256).max - block.timestamp);
 
         // Set timestamp in future
@@ -1290,7 +1302,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
                               REFRESH PRICE
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzOnlyAuthorizedCanRefreshPrice(address caller) public {
+    function testFuzzOnlyAuthorizedCanRefreshPrice(
+        address caller
+    ) public {
         vm.assume(caller != owner && caller != treasurer);
 
         vm.prank(caller);
@@ -1344,7 +1358,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.credit(fid, units);
     }
 
-    function testFuzzCreditRevertsZeroUnits(uint256 fid) public {
+    function testFuzzCreditRevertsZeroUnits(
+        uint256 fid
+    ) public {
         vm.expectRevert(StorageRegistry.InvalidAmount.selector);
         vm.prank(operator);
         storageRegistry.credit(fid, 0);
@@ -1367,7 +1383,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         _batchCreditStorage(fids, units);
     }
 
-    function testFuzzBatchCreditRevertsZeroAmount(uint256[] calldata fids) public {
+    function testFuzzBatchCreditRevertsZeroAmount(
+        uint256[] calldata fids
+    ) public {
         vm.expectRevert(StorageRegistry.InvalidAmount.selector);
         vm.prank(operator);
         storageRegistry.batchCredit(fids, 0);
@@ -1510,7 +1528,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setPriceFeed(AggregatorV3Interface(newFeed));
     }
 
-    function testFuzzSetPriceFeed(address newFeed) public {
+    function testFuzzSetPriceFeed(
+        address newFeed
+    ) public {
         AggregatorV3Interface currentFeed = storageRegistry.priceFeed();
 
         vm.expectEmit();
@@ -1530,7 +1550,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setUptimeFeed(AggregatorV3Interface(newFeed));
     }
 
-    function testFuzzSetUptimeFeed(address newFeed) public {
+    function testFuzzSetUptimeFeed(
+        address newFeed
+    ) public {
         AggregatorV3Interface currentFeed = storageRegistry.uptimeFeed();
 
         vm.expectEmit();
@@ -1554,7 +1576,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setPrice(unitPrice);
     }
 
-    function testFuzzSetUSDUnitPrice(uint256 unitPrice) public {
+    function testFuzzSetUSDUnitPrice(
+        uint256 unitPrice
+    ) public {
         uint256 currentPrice = storageRegistry.usdUnitPrice();
 
         vm.expectEmit(false, false, false, true);
@@ -1578,7 +1602,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setFixedEthUsdPrice(fixedPrice);
     }
 
-    function testFuzzSetFixedEthUsdPrice(uint256 fixedPrice) public {
+    function testFuzzSetFixedEthUsdPrice(
+        uint256 fixedPrice
+    ) public {
         fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         assertEq(storageRegistry.fixedEthUsdPrice(), 0);
 
@@ -1591,7 +1617,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.fixedEthUsdPrice(), fixedPrice);
     }
 
-    function testFuzzSetFixedEthUsdPriceRevertsLessThanMinPrice(uint256 fixedPrice) public {
+    function testFuzzSetFixedEthUsdPriceRevertsLessThanMinPrice(
+        uint256 fixedPrice
+    ) public {
         fixedPrice = bound(fixedPrice, 1, storageRegistry.priceFeedMinAnswer() - 1);
         assertEq(storageRegistry.fixedEthUsdPrice(), 0);
 
@@ -1600,7 +1628,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setFixedEthUsdPrice(fixedPrice);
     }
 
-    function testFuzzSetFixedEthUsdPriceRevertsGreaterThanMaxPrice(uint256 fixedPrice) public {
+    function testFuzzSetFixedEthUsdPriceRevertsGreaterThanMaxPrice(
+        uint256 fixedPrice
+    ) public {
         fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMaxAnswer() + 1, type(uint256).max);
         assertEq(storageRegistry.fixedEthUsdPrice(), 0);
 
@@ -1609,7 +1639,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setFixedEthUsdPrice(fixedPrice);
     }
 
-    function testFuzzSetFixedEthUsdPriceOverridesPriceFeed(uint256 fixedPrice) public {
+    function testFuzzSetFixedEthUsdPriceOverridesPriceFeed(
+        uint256 fixedPrice
+    ) public {
         fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         vm.assume(fixedPrice != storageRegistry.ethUsdPrice());
         fixedPrice = bound(fixedPrice, 1, type(uint256).max);
@@ -1626,7 +1658,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(priceAfter, usdUnitPrice.divWadUp(fixedPrice));
     }
 
-    function testFuzzRemoveFixedEthUsdPriceReenablesPriceFeed(uint256 fixedPrice) public {
+    function testFuzzRemoveFixedEthUsdPriceReenablesPriceFeed(
+        uint256 fixedPrice
+    ) public {
         fixedPrice = bound(fixedPrice, storageRegistry.priceFeedMinAnswer(), storageRegistry.priceFeedMaxAnswer());
         vm.assume(fixedPrice != storageRegistry.ethUsdPrice());
         fixedPrice = bound(fixedPrice, 1, type(uint256).max);
@@ -1662,7 +1696,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setMaxUnits(maxUnits);
     }
 
-    function testFuzzSetMaxUnitsEmitsEvent(uint256 maxUnits) public {
+    function testFuzzSetMaxUnitsEmitsEvent(
+        uint256 maxUnits
+    ) public {
         uint256 currentMax = storageRegistry.maxUnits();
 
         vm.expectEmit(false, false, false, true);
@@ -1686,7 +1722,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setDeprecationTimestamp(timestamp);
     }
 
-    function testFuzzSetDeprecationTime(uint256 timestamp) public {
+    function testFuzzSetDeprecationTime(
+        uint256 timestamp
+    ) public {
         timestamp = bound(timestamp, block.timestamp, type(uint256).max);
         uint256 currentEnd = storageRegistry.deprecationTimestamp();
 
@@ -1699,7 +1737,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.deprecationTimestamp(), timestamp);
     }
 
-    function testFuzzSetDeprecationTimeRevertsInPast(uint256 timestamp) public {
+    function testFuzzSetDeprecationTimeRevertsInPast(
+        uint256 timestamp
+    ) public {
         timestamp = bound(timestamp, 1, type(uint256).max);
         vm.warp(timestamp);
 
@@ -1722,7 +1762,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setCacheDuration(duration);
     }
 
-    function testFuzzSetCacheDuration(uint256 duration) public {
+    function testFuzzSetCacheDuration(
+        uint256 duration
+    ) public {
         uint256 currentDuration = storageRegistry.priceFeedCacheDuration();
 
         vm.expectEmit(false, false, false, true);
@@ -1746,7 +1788,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setMaxAge(age);
     }
 
-    function testFuzzSetMaxAge(uint256 age) public {
+    function testFuzzSetMaxAge(
+        uint256 age
+    ) public {
         uint256 currentAge = storageRegistry.priceFeedMaxAge();
 
         vm.expectEmit(false, false, false, true);
@@ -1770,7 +1814,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setMinAnswer(answer);
     }
 
-    function testFuzzSetMinAnswer(uint256 answer) public {
+    function testFuzzSetMinAnswer(
+        uint256 answer
+    ) public {
         answer = bound(answer, 0, storageRegistry.priceFeedMaxAnswer() - 1);
         uint256 currentMin = storageRegistry.priceFeedMinAnswer();
 
@@ -1783,7 +1829,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.priceFeedMinAnswer(), answer);
     }
 
-    function testFuzzCannotSetMinEqualOrAboveMax(uint256 answer) public {
+    function testFuzzCannotSetMinEqualOrAboveMax(
+        uint256 answer
+    ) public {
         answer = bound(answer, storageRegistry.priceFeedMaxAnswer(), type(uint256).max);
 
         vm.prank(owner);
@@ -1799,7 +1847,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setMaxAnswer(answer);
     }
 
-    function testFuzzSetMaxAnswer(uint256 answer) public {
+    function testFuzzSetMaxAnswer(
+        uint256 answer
+    ) public {
         answer = bound(answer, storageRegistry.priceFeedMinAnswer() + 1, type(uint256).max);
         uint256 currentMax = storageRegistry.priceFeedMaxAnswer();
 
@@ -1812,7 +1862,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.priceFeedMaxAnswer(), answer);
     }
 
-    function testFuzzCannotSetMaxEqualOrBelowMin(uint256 answer) public {
+    function testFuzzCannotSetMaxEqualOrBelowMin(
+        uint256 answer
+    ) public {
         answer = bound(answer, 0, storageRegistry.priceFeedMinAnswer());
 
         vm.prank(owner);
@@ -1832,7 +1884,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.setGracePeriod(duration);
     }
 
-    function testFuzzSetGracePeriod(uint256 duration) public {
+    function testFuzzSetGracePeriod(
+        uint256 duration
+    ) public {
         uint256 currentGracePeriod = storageRegistry.uptimeFeedGracePeriod();
 
         vm.expectEmit(false, false, false, true);
@@ -1848,7 +1902,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
                                 SET VAULT
     //////////////////////////////////////////////////////////////*/
 
-    function testFuzzSetVault(address newVault) public {
+    function testFuzzSetVault(
+        address newVault
+    ) public {
         vm.assume(newVault != address(0));
         vm.expectEmit(false, false, false, true);
         emit SetVault(vault, newVault);
@@ -1891,7 +1947,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(storageRegistry.paused(), false);
     }
 
-    function testFuzzOnlyOwnerCanPause(address caller) public {
+    function testFuzzOnlyOwnerCanPause(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -1899,7 +1957,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.pause();
     }
 
-    function testFuzzOnlyOwnerCanUnpause(address caller) public {
+    function testFuzzOnlyOwnerCanUnpause(
+        address caller
+    ) public {
         vm.assume(caller != owner);
 
         vm.prank(caller);
@@ -1931,7 +1991,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         assertEq(balanceChange, amount);
     }
 
-    function testFuzzWithdrawalRevertsInsufficientFunds(uint256 amount) public {
+    function testFuzzWithdrawalRevertsInsufficientFunds(
+        uint256 amount
+    ) public {
         // Ensure amount is >=0 and deal a smaller amount to the contract
         amount = bound(amount, 1, type(uint256).max);
         vm.deal(address(storageRegistry), amount - 1);
@@ -1941,7 +2003,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.withdraw(amount);
     }
 
-    function testFuzzWithdrawalRevertsCallFailed(uint256 amount) public {
+    function testFuzzWithdrawalRevertsCallFailed(
+        uint256 amount
+    ) public {
         vm.deal(address(storageRegistry), amount);
 
         vm.prank(owner);
@@ -1961,7 +2025,9 @@ contract StorageRegistryTest is StorageRegistryTestSuite {
         storageRegistry.withdraw(amount);
     }
 
-    function testFuzzWithdraw(uint256 amount) public {
+    function testFuzzWithdraw(
+        uint256 amount
+    ) public {
         // Deal an amount > 1 wei so we can withraw at least 1
         amount = bound(amount, 2, type(uint256).max);
         vm.deal(address(storageRegistry), amount);

--- a/test/TestSuiteSetup.sol
+++ b/test/TestSuiteSetup.sol
@@ -49,38 +49,44 @@ abstract contract TestSuiteSetup is Test {
                                  HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    function addKnownContract(address contractAddress) public {
+    function addKnownContract(
+        address contractAddress
+    ) public {
         isKnownContract[contractAddress] = true;
     }
 
     // Ensures that a fuzzed address input does not match a known contract address
-    function _assumeClean(address a) internal {
+    function _assumeClean(
+        address a
+    ) internal {
         assumeNoPrecompiles(a);
         vm.assume(!isKnownContract[a]);
         vm.assume(a != ADMIN);
         vm.assume(a != address(0));
     }
 
-    function _boundPk(uint256 pk) internal view returns (uint256) {
+    function _boundPk(
+        uint256 pk
+    ) internal view returns (uint256) {
         return bound(pk, 1, SECP_256K1_ORDER - 1);
     }
 
-    function _boundDeadline(uint40 deadline) internal view returns (uint256) {
+    function _boundDeadline(
+        uint40 deadline
+    ) internal view returns (uint256) {
         return block.timestamp + uint256(bound(deadline, 0, type(uint40).max));
     }
 
-    function _createMockERC1271(address ownerAddress)
-        internal
-        returns (ERC1271WalletMock mockWallet, address mockWalletAddress)
-    {
+    function _createMockERC1271(
+        address ownerAddress
+    ) internal returns (ERC1271WalletMock mockWallet, address mockWalletAddress) {
         mockWallet = new ERC1271WalletMock(ownerAddress);
         mockWalletAddress = address(mockWallet);
     }
 
-    function _createMaliciousMockERC1271(address ownerAddress)
-        internal
-        returns (ERC1271MaliciousMockForceRevert mockWallet, address mockWalletAddress)
-    {
+    function _createMaliciousMockERC1271(
+        address ownerAddress
+    ) internal returns (ERC1271MaliciousMockForceRevert mockWallet, address mockWalletAddress) {
         mockWallet = new ERC1271MaliciousMockForceRevert(ownerAddress);
         mockWalletAddress = address(mockWallet);
     }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -64,7 +64,9 @@ contract StubValidator {
         return isValid;
     }
 
-    function setIsValid(bool val) external {
+    function setIsValid(
+        bool val
+    ) external {
         isValid = val;
     }
 }
@@ -92,23 +94,33 @@ contract MockChainlinkFeed is AggregatorV3Interface {
         description = _description;
     }
 
-    function setShouldRevert(bool _shouldRevert) external {
+    function setShouldRevert(
+        bool _shouldRevert
+    ) external {
         shouldRevert = _shouldRevert;
     }
 
-    function setStubTimeStamp(bool _stubTimeStamp) external {
+    function setStubTimeStamp(
+        bool _stubTimeStamp
+    ) external {
         stubTimeStamp = _stubTimeStamp;
     }
 
-    function setAnswer(int256 value) external {
+    function setAnswer(
+        int256 value
+    ) external {
         roundData.answer = value;
     }
 
-    function setRoundData(RoundData calldata _roundData) external {
+    function setRoundData(
+        RoundData calldata _roundData
+    ) external {
         roundData = _roundData;
     }
 
-    function getRoundData(uint80) external view returns (uint80, int256, uint256, uint256, uint80) {
+    function getRoundData(
+        uint80
+    ) external view returns (uint80, int256, uint256, uint256, uint80) {
         return latestRoundData();
     }
 
@@ -125,7 +137,9 @@ contract MockChainlinkFeed is AggregatorV3Interface {
 }
 
 contract MockPriceFeed is MockChainlinkFeed(8, "Mock ETH/USD Price Feed") {
-    function setPrice(int256 _price) external {
+    function setPrice(
+        int256 _price
+    ) external {
         roundData.answer = _price;
     }
 }
@@ -143,7 +157,9 @@ contract RevertOnReceive {
 //////////////////////////////////////////////////////////////*/
 
 contract ERC1271WalletMock is Ownable, IERC1271 {
-    constructor(address owner) {
+    constructor(
+        address owner
+    ) {
         super.transferOwnership(owner);
     }
 
@@ -156,11 +172,15 @@ contract ERC1271WalletMock is Ownable, IERC1271 {
 contract ERC1271MaliciousMockForceRevert is Ownable, IERC1271 {
     bool internal _forceRevert = true;
 
-    constructor(address owner) {
+    constructor(
+        address owner
+    ) {
         super.transferOwnership(owner);
     }
 
-    function setForceRevert(bool forceRevert) external {
+    function setForceRevert(
+        bool forceRevert
+    ) external {
         _forceRevert = forceRevert;
     }
 

--- a/test/abstract/Guardians/Guardians.symbolic.t.sol
+++ b/test/abstract/Guardians/Guardians.symbolic.t.sol
@@ -7,7 +7,9 @@ import {Test} from "forge-std/Test.sol";
 import {Guardians} from "../../../src/abstract/Guardians.sol";
 
 contract GuardiansExample is Guardians {
-    constructor(address owner) Guardians(owner) {}
+    constructor(
+        address owner
+    ) Guardians(owner) {}
 }
 
 contract GuardiansSymTest is SymTest, Test {
@@ -108,7 +110,9 @@ contract GuardiansSymTest is SymTest, Test {
     /**
      * @dev Generates valid calldata for a given function selector.
      */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
+    function _calldataFor(
+        bytes4 selector
+    ) internal returns (bytes memory) {
         return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }

--- a/test/abstract/Migration/Migration.symbolic.t.sol
+++ b/test/abstract/Migration/Migration.symbolic.t.sol
@@ -112,7 +112,9 @@ contract MigrationSymTest is SymTest, Test {
     /**
      * @dev Generates valid calldata for a given function selector.
      */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
+    function _calldataFor(
+        bytes4 selector
+    ) internal returns (bytes memory) {
         return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }

--- a/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
+++ b/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidator.t.sol
@@ -308,7 +308,9 @@ contract SignedKeyRequestValidatorTest is SignedKeyRequestValidatorTestSuite {
         validator.setIdRegistry(idRegistry);
     }
 
-    function testFuzzSetIdRegistry(address idRegistry) public {
+    function testFuzzSetIdRegistry(
+        address idRegistry
+    ) public {
         address currentIdRegistry = address(validator.idRegistry());
 
         vm.expectEmit(false, false, false, true);

--- a/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidatorTestSuite.sol
+++ b/test/validators/SignedKeyRequestValidator/SignedKeyRequestValidatorTestSuite.sol
@@ -16,7 +16,9 @@ abstract contract SignedKeyRequestValidatorTestSuite is IdRegistryTestSuite {
         validator = new SignedKeyRequestValidator(address(idRegistry), owner);
     }
 
-    function _validKey(bytes memory keyBytes) internal pure returns (bytes memory) {
+    function _validKey(
+        bytes memory keyBytes
+    ) internal pure returns (bytes memory) {
         if (keyBytes.length < 32) {
             // pad with zero bytes
             bytes memory padding = new bytes(32 - keyBytes.length);


### PR DESCRIPTION
## Motivation

The behavior of the `forge fmt` code formatter has changed since we last touched the contracts repo. Rather than fight the formatter, we should adopt standard style.

## Change Summary

Update foundry to latest stable and run `forge fmt` to reformat existing code.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [x] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving the formatting of function signatures across various Solidity files. It enhances readability by aligning parameters vertically. 

### Detailed summary
- Updated function signatures to have parameters on new lines for readability in multiple files.
- Adjusted `setMigrator`, `price`, `runDeploy`, `hashTypedDataV4`, and other functions to follow this style.
- Modified several test functions similarly for consistency.
- Made minor adjustments to the `Dockerfile` to install `netcat-openbsd` instead of `netcat`.
- Updated CI workflow to use stable version of Foundry instead of nightly.

> The following files were skipped due to too many changes: `test/StorageRegistry/StorageRegistry.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->