### PR TITLE
chore: upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -123,7 +123,7 @@ jobs:
     container:
       image: ghcr.io/a16z/halmos:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -139,7 +139,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
Updated GitHub Actions workflow to use actions/checkout@v4 instead of v3. 

Reference: https://github.com/actions/checkout/releases/tag/v4.2.2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `actions/checkout` version in the GitHub Actions workflow configuration from `v3` to `v4`, enhancing the checkout process for the CI pipeline.

### Detailed summary
- Updated `actions/checkout` from `v3` to `v4` in multiple job definitions within `.github/workflows/ci.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->