### PR TITLE
fix: Mismatch constructor parameters in DeployL2 script

### DIFF
--- a/script/DeployL2.s.sol
+++ b/script/DeployL2.s.sol
@@ -121,7 +121,7 @@ contract DeployL2 is ImmutableCreate2Deployer {
             "KeyGateway",
             params.salts.keyGateway,
             type(KeyGateway).creationCode,
-            abi.encode(addrs.keyRegistry, addrs.storageRegistry, params.initialKeyRegistryOwner)
+            abi.encode(addrs.keyRegistry, params.initialKeyRegistryOwner)
         );
         addrs.signedKeyRequestValidator = register(
             "SignedKeyRequestValidator",


### PR DESCRIPTION
## Problem
As reported in #415, the `KeyGateway` constructor in `src/KeyGateway.sol` expects only two parameters (`address _keyRegistry`, `address _initialOwner`), but the deployment script `DeployL2.s.sol` was incorrectly passing three parameters (`addrs.keyRegistry`, `addrs.storageRegistry`, `params.initialKeyRegistryOwner`).

## Solution  
Removed the unused `addrs.storageRegistry` from the `abi.encode` call when verifying/deploying the `KeyGateway` in `script/DeployL2.s.sol`.

## Testing
Successfully built the project using `forge build` to verify that it resolves any ABI mismatch issues.

Closes #415

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the parameters passed to the `register` function for the `KeyGateway` deployment, specifically reducing the number of arguments encoded.

### Detailed summary
- Removed `addrs.storageRegistry` from the parameters passed to `abi.encode` in the deployment of `KeyGateway`.
- Updated the encoding to only include `addrs.keyRegistry` and `params.initialKeyRegistryOwner`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->