### PR TITLE
feat: SnapchainConfigRegistry storage, mutators, and events

### DIFF
--- a/src/SnapchainConfigRegistry.sol
+++ b/src/SnapchainConfigRegistry.sol
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+import {Ownable2Step} from "openzeppelin/contracts/access/Ownable2Step.sol";
+
+import {ISnapchainConfigRegistry} from "./interfaces/ISnapchainConfigRegistry.sol";
+
+/**
+ * @title SnapchainConfigRegistry
+ *
+ * @notice Canonical, owner-governed record of a Snapchain network's validator sets and gossip peer
+ *         lists. Validator-set history is append-only: earlier entries are immutable, and only the
+ *         latest may be amended or removed. Peer lists are plain settable strings.
+ *
+ * @notice See https://github.com/farcasterxyz/contracts/blob/main/docs/snapchain-config-registry.md
+ *         for the schema and the rendered-output specification.
+ *
+ * @custom:security-contact security@merklemanufactory.com
+ */
+contract SnapchainConfigRegistry is ISnapchainConfigRegistry, Ownable2Step {
+    /*//////////////////////////////////////////////////////////////
+                                CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    string public constant VERSION = "2026.08.04";
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    uint256 public constant MAX_SHARD_IDS = 16;
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    uint256 public constant MAX_VALIDATOR_PUBLIC_KEYS = 128;
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    uint256 public constant MAX_PEER_STRING_LENGTH = 8192;
+
+    /**
+     * @dev Allowlist of bytes permitted in a peer string, as a bitmap over 0x00-0x3F. Bit i is set
+     *      if byte i is allowed. Covers space, comma, hyphen, period, slash, the digits, and colon.
+     *
+     *      Anything a multiaddr or base58 peer id can contain is here; nothing else is. In
+     *      particular the quote and backslash are excluded, which is what makes it impossible for a
+     *      peer string to escape the TOML literal it is rendered into.
+     */
+    uint256 internal constant _PEER_CHARS_LO = 0x07FFF00100000000;
+
+    /**
+     * @dev Allowlist bitmap over 0x40-0x7F; bit i is set if byte (0x40 + i) is allowed. Covers the
+     *      uppercase letters, underscore, and the lowercase letters.
+     */
+    uint256 internal constant _PEER_CHARS_HI = 0x07FFFFFE87FFFFFE;
+
+    /*//////////////////////////////////////////////////////////////
+                                STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Validator sets in append order. Held internal with explicit accessors because the
+     *      compiler-generated getter for an array of structs with nested dynamic arrays returns
+     *      only the value-type members.
+     */
+    ValidatorSet[] internal _validatorSets;
+
+    /**
+     * @dev Highest `effectiveAt` across every stored set governing each shard.
+     *
+     *      Because a set's `effectiveAt` is bounded below by this value at write time, the running
+     *      value is both the maximum and the most recent, which is what the bound in §2.3 of
+     *      docs/snapchain-config-registry.md is defined against. Zero for a shard no set governs,
+     *      which correctly imposes no bound.
+     */
+    mapping(uint32 shardId => uint64 effectiveAt) internal _lastEffectiveAt;
+
+    /**
+     * @dev For each stored set, the value `_lastEffectiveAt` held for each of that set's shards
+     *      immediately before the set was written, positionally aligned with its `shardIds`.
+     *
+     *      This is what makes the tip mutable in constant time. Amending or removing a set has to
+     *      undo that set's contribution to `_lastEffectiveAt` before the bound can be re-evaluated
+     *      against the sets preceding it, and the contribution is not otherwise recoverable: the
+     *      mapping keeps a running maximum, not a history. Snapshotting per set rather than only
+     *      for the tip keeps repeated removals correct, since each removal exposes a new tip whose
+     *      own predecessor values must still be known.
+     */
+    uint64[][] internal _priorEffectiveAt;
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    uint256 public configVersion;
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    string public bootstrapPeers;
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    string public directPeers;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Set the initial owner.
+     *
+     * @dev Deliberately takes no config. Seeding happens after deployment, which keeps the creation
+     *      code independent of the config payload so that revising seed data before launch does not
+     *      change the deployed address.
+     *
+     * @param _initialOwner Address of the contract owner.
+     */
+    constructor(
+        address _initialOwner
+    ) {
+        _transferOwnership(_initialOwner);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                GETTERS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function validatorSetCount() public view returns (uint256) {
+        return _validatorSets.length;
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function validatorSetAt(
+        uint256 index
+    ) public view returns (ValidatorSet memory) {
+        if (index >= _validatorSets.length) revert InvalidRange();
+        return _validatorSets[index];
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function validatorSets() external view returns (ValidatorSet[] memory) {
+        uint256 count = _validatorSets.length;
+        ValidatorSet[] memory sets = new ValidatorSet[](count);
+        for (uint256 i; i < count; ++i) {
+            sets[i] = _validatorSets[i];
+        }
+        return sets;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         PERMISSIONED ACTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function appendValidatorSet(
+        uint64 effectiveAt,
+        uint32[] calldata shardIds,
+        bytes32[] calldata validatorPublicKeys
+    ) external onlyOwner {
+        uint256 index = _validatorSets.length;
+        _validatorSets.push();
+        _priorEffectiveAt.push();
+        _writeValidatorSet(index, effectiveAt, shardIds, validatorPublicKeys);
+
+        emit AppendValidatorSet(index, effectiveAt, shardIds, validatorPublicKeys, ++configVersion);
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function amendLatestValidatorSet(
+        uint64 effectiveAt,
+        uint32[] calldata shardIds,
+        bytes32[] calldata validatorPublicKeys
+    ) external onlyOwner {
+        uint256 count = _validatorSets.length;
+        if (count == 0) revert NoValidatorSets();
+
+        uint256 index = count - 1;
+        _writeValidatorSet(index, effectiveAt, shardIds, validatorPublicKeys);
+
+        emit AmendValidatorSet(index, effectiveAt, shardIds, validatorPublicKeys, ++configVersion);
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function removeLatestValidatorSet() external onlyOwner {
+        uint256 count = _validatorSets.length;
+        if (count == 0) revert NoValidatorSets();
+
+        uint256 index = count - 1;
+        _rollBackEffectiveAt(index);
+
+        // pop() is specified to clear the nested dynamic arrays, but clearing them explicitly means
+        // that getting this wrong is not possible: a later push() inheriting stale contents would
+        // silently resurrect a removed validator.
+        ValidatorSet storage validatorSet = _validatorSets[index];
+        delete validatorSet.shardIds;
+        delete validatorSet.validatorPublicKeys;
+        _validatorSets.pop();
+
+        delete _priorEffectiveAt[index];
+        _priorEffectiveAt.pop();
+
+        emit RemoveValidatorSet(index, ++configVersion);
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function setBootstrapPeers(
+        string calldata peers
+    ) external onlyOwner {
+        _validatePeerString(peers);
+
+        emit SetBootstrapPeers(bootstrapPeers, peers, ++configVersion);
+
+        bootstrapPeers = peers;
+    }
+
+    /**
+     * @inheritdoc ISnapchainConfigRegistry
+     */
+    function setDirectPeers(
+        string calldata peers
+    ) external onlyOwner {
+        _validatePeerString(peers);
+
+        emit SetDirectPeers(directPeers, peers, ++configVersion);
+
+        directPeers = peers;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Validate and write a validator set at `index`, which must already exist.
+     *
+     *      Append and amend share this one path, so an amend cannot drift from an append, and
+     *      amending entry N is bounded by the entries before it for free. Members are assigned
+     *      individually rather than assigning a whole struct, which sidesteps the compiler's
+     *      unimplemented memory-to-storage copy for structs with nested dynamic arrays and
+     *      correctly resizes the existing arrays on an amend.
+     */
+    function _writeValidatorSet(
+        uint256 index,
+        uint64 effectiveAt,
+        uint32[] calldata shardIds,
+        bytes32[] calldata validatorPublicKeys
+    ) internal {
+        _validateShardIds(shardIds);
+        _validateValidatorPublicKeys(validatorPublicKeys);
+
+        // On an amend this entry already contributes to `_lastEffectiveAt`; undo that first so the
+        // incoming value is bounded by the entries preceding it rather than by the value it is
+        // replacing. On an append the entry was just pushed and governs no shards, so this is a
+        // no-op and the two paths stay identical.
+        _rollBackEffectiveAt(index);
+        _applyEffectiveAt(index, effectiveAt, shardIds);
+
+        ValidatorSet storage validatorSet = _validatorSets[index];
+        validatorSet.effectiveAt = effectiveAt;
+        validatorSet.shardIds = shardIds;
+        validatorSet.validatorPublicKeys = validatorPublicKeys;
+    }
+
+    /**
+     * @dev Bound `effectiveAt` against the most recent preceding set **for each shard this set
+     *      governs**, then record it at `index`.
+     *
+     *      The comparison is per shard because `effectiveAt` is a per-shard Snapchain block height.
+     *      Shard 0 and the message shards advance on independent counters, so two sets governing
+     *      disjoint shards carry heights on different clocks and cannot be meaningfully ordered
+     *      against each other. Bounding a set against its immediate array predecessor regardless of
+     *      shard would make a legitimate rollout unrepresentable: with shard 0 last set at height
+     *      50_000_000 and shard 1 currently at 30_000_000, no correct shard-1 set could be appended,
+     *      and the only accepted values would activate it at the wrong height.
+     *
+     *      Sets governing disjoint shards are therefore unconstrained relative to one another.
+     *      Within a shard the bound is `>=` rather than `>`, since a rollout may legitimately land
+     *      at a height already used by a sibling set.
+     *
+     *      Snapchain's own scan is order-independent (see the ordering section of
+     *      docs/snapchain-config-registry.md), so this is a guard against operator error rather than
+     *      a consumer requirement. It is worth keeping: a too-low height for a shard backdates that
+     *      set over already-committed blocks, changing which keys verify historical commits and
+     *      breaking sync from genesis.
+     *
+     *      Reverting partway leaves the writes above it to be rolled back with the transaction, so
+     *      checking and recording in one pass is safe. Duplicate shard ids are already rejected, so
+     *      no shard is visited twice.
+     */
+    function _applyEffectiveAt(uint256 index, uint64 effectiveAt, uint32[] calldata shardIds) internal {
+        uint256 shardCount = shardIds.length;
+        uint64[] memory priors = new uint64[](shardCount);
+
+        for (uint256 i; i < shardCount; ++i) {
+            uint32 shardId = shardIds[i];
+            uint64 prior = _lastEffectiveAt[shardId];
+            if (effectiveAt < prior) revert InvalidEffectiveAt();
+
+            priors[i] = prior;
+            _lastEffectiveAt[shardId] = effectiveAt;
+        }
+
+        _priorEffectiveAt[index] = priors;
+    }
+
+    /**
+     * @dev Undo the contribution the set at `index` made to `_lastEffectiveAt`, restoring the value
+     *      each of its shards held immediately before it was written.
+     *
+     *      Exact rather than approximate: the snapshot is taken per set, so this restores the bound
+     *      to what the preceding sets imply even after the tip has been amended repeatedly or
+     *      several sets have been removed in turn.
+     *
+     *      A set that governs no shards — the empty entry `appendValidatorSet` pushes before writing
+     *      — contributes nothing, so this is a no-op there.
+     */
+    function _rollBackEffectiveAt(
+        uint256 index
+    ) internal {
+        uint32[] storage shardIds = _validatorSets[index].shardIds;
+        uint64[] storage priors = _priorEffectiveAt[index];
+
+        uint256 shardCount = shardIds.length;
+        for (uint256 i; i < shardCount; ++i) {
+            _lastEffectiveAt[shardIds[i]] = priors[i];
+        }
+    }
+
+    /**
+     * @dev Require a non-empty, bounded, duplicate-free list of shard ids.
+     */
+    function _validateShardIds(
+        uint32[] calldata shardIds
+    ) internal pure {
+        uint256 length = shardIds.length;
+        if (length == 0 || length > MAX_SHARD_IDS) revert InvalidShardIds();
+
+        for (uint256 i; i < length; ++i) {
+            for (uint256 j = i + 1; j < length; ++j) {
+                if (shardIds[i] == shardIds[j]) revert InvalidShardIds();
+            }
+        }
+    }
+
+    /**
+     * @dev Require a non-empty, bounded, duplicate-free list of non-zero public keys.
+     *
+     *      A duplicate key would silently double that operator's voting weight, so this is a safety
+     *      property rather than hygiene. Ed25519 point validity is deliberately not checked: there
+     *      is no cheap onchain test, and an invalid point fails loudly at node startup.
+     */
+    function _validateValidatorPublicKeys(
+        bytes32[] calldata validatorPublicKeys
+    ) internal pure {
+        uint256 length = validatorPublicKeys.length;
+        if (length == 0 || length > MAX_VALIDATOR_PUBLIC_KEYS) revert InvalidValidatorPublicKeys();
+
+        for (uint256 i; i < length; ++i) {
+            if (validatorPublicKeys[i] == bytes32(0)) revert InvalidValidatorPublicKeys();
+            for (uint256 j = i + 1; j < length; ++j) {
+                if (validatorPublicKeys[i] == validatorPublicKeys[j]) revert InvalidValidatorPublicKeys();
+            }
+        }
+    }
+
+    /**
+     * @dev Require every byte of a peer string to be in the allowlist. The empty string is valid:
+     *      Snapchain defaults both peer lists to empty and a seed node legitimately has none.
+     *
+     *      Offending input is rejected rather than sanitized. Silently stripping characters would
+     *      store a value the owner did not write and hide the mistake at the moment it matters.
+     */
+    function _validatePeerString(
+        string calldata peers
+    ) internal pure {
+        bytes calldata raw = bytes(peers);
+        uint256 length = raw.length;
+        if (length > MAX_PEER_STRING_LENGTH) revert InvalidPeerString();
+
+        for (uint256 i; i < length; ++i) {
+            uint8 char = uint8(raw[i]);
+            if (char > 0x7F) revert InvalidPeerString();
+            uint256 allowed = char < 0x40 ? _PEER_CHARS_LO : _PEER_CHARS_HI;
+            // Parenthesised for the reader, not the compiler: Solidity binds `&` tighter than
+            // `==`, the opposite of C, so this groups correctly either way.
+            if (((allowed >> (char & 0x3F)) & 1) == 0) revert InvalidPeerString();
+        }
+    }
+}

--- a/src/interfaces/ISnapchainConfigRegistry.sol
+++ b/src/interfaces/ISnapchainConfigRegistry.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+/**
+ * @title ISnapchainConfigRegistry
+ *
+ * @notice Interface for the SnapchainConfigRegistry contract, which holds the canonical validator
+ *         sets and gossip peer lists for a Snapchain network.
+ *
+ * @custom:security-contact security@merklemanufactory.com
+ */
+interface ISnapchainConfigRegistry {
+    /**
+     * @notice One validator set, effective from a given Snapchain block height onward.
+     *
+     * @param effectiveAt          Snapchain block height at which this set becomes active. This is a
+     *                             Snapchain height, not an EVM block number and not a timestamp.
+     *                             Nothing onchain can validate it.
+     * @param shardIds             Shards this set governs. 0 is the block shard, 1 and above are
+     *                             message shards.
+     * @param validatorPublicKeys  Ed25519 public keys of the validators in this set. Stored as
+     *                             bytes32 rather than hex strings so that rendering can only ever
+     *                             emit characters from a fixed hex alphabet.
+     */
+    struct ValidatorSet {
+        uint64 effectiveAt;
+        uint32[] shardIds;
+        bytes32[] validatorPublicKeys;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Revert if shardIds is empty, exceeds MAX_SHARD_IDS, or contains a duplicate.
+    error InvalidShardIds();
+
+    /// @dev Revert if validatorPublicKeys is empty, exceeds MAX_VALIDATOR_PUBLIC_KEYS, or contains
+    ///      a zero or duplicate key.
+    error InvalidValidatorPublicKeys();
+
+    /// @dev Revert if effectiveAt is lower than that of the most recent preceding validator set
+    ///      governing a shard in common. Entries governing disjoint shards are unconstrained
+    ///      relative to one another, since each shard's height is an independent counter.
+    error InvalidEffectiveAt();
+
+    /// @dev Revert if the caller amends or removes the latest validator set while there are none.
+    error NoValidatorSets();
+
+    /// @dev Revert if a peer string exceeds MAX_PEER_STRING_LENGTH or contains a byte outside the
+    ///      allowlist. See the "TOML injection" section of docs/snapchain-config-registry.md.
+    error InvalidPeerString();
+
+    /// @dev Revert if a validator set index or range falls outside the stored array.
+    error InvalidRange();
+
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Emitted when a validator set is appended.
+     * @dev Carries the full payload so an indexer can reconstruct the rendered document from logs
+     *      alone, with no archive-node call per historical block.
+     * @param index                Index of the appended set.
+     * @param effectiveAt          Snapchain block height at which the set becomes active.
+     * @param shardIds             Shards this set governs.
+     * @param validatorPublicKeys  Ed25519 public keys in the set.
+     * @param configVersion        Registry version after this change.
+     */
+    event AppendValidatorSet(
+        uint256 indexed index,
+        uint64 indexed effectiveAt,
+        uint32[] shardIds,
+        bytes32[] validatorPublicKeys,
+        uint256 configVersion
+    );
+
+    /**
+     * @notice Emitted when the latest validator set is amended in place.
+     * @param index                Index of the amended set.
+     * @param effectiveAt          Snapchain block height at which the set becomes active.
+     * @param shardIds             Shards this set governs.
+     * @param validatorPublicKeys  Ed25519 public keys in the set.
+     * @param configVersion        Registry version after this change.
+     */
+    event AmendValidatorSet(
+        uint256 indexed index,
+        uint64 indexed effectiveAt,
+        uint32[] shardIds,
+        bytes32[] validatorPublicKeys,
+        uint256 configVersion
+    );
+
+    /**
+     * @notice Emitted when the latest validator set is removed.
+     * @param index         Index the removed set occupied.
+     * @param configVersion Registry version after this change.
+     */
+    event RemoveValidatorSet(uint256 indexed index, uint256 configVersion);
+
+    /**
+     * @notice Emitted when the bootstrap peer list is set.
+     * @param oldPeers      Previous value.
+     * @param newPeers      New value.
+     * @param configVersion Registry version after this change.
+     */
+    event SetBootstrapPeers(string oldPeers, string newPeers, uint256 configVersion);
+
+    /**
+     * @notice Emitted when the direct peer list is set.
+     * @param oldPeers      Previous value.
+     * @param newPeers      New value.
+     * @param configVersion Registry version after this change.
+     */
+    event SetDirectPeers(string oldPeers, string newPeers, uint256 configVersion);
+
+    /*//////////////////////////////////////////////////////////////
+                                CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Contract version specified in the Farcaster protocol version scheme.
+     */
+    function VERSION() external view returns (string memory);
+
+    /**
+     * @notice Maximum number of shard ids in a single validator set.
+     */
+    function MAX_SHARD_IDS() external view returns (uint256);
+
+    /**
+     * @notice Maximum number of public keys in a single validator set.
+     */
+    function MAX_VALIDATOR_PUBLIC_KEYS() external view returns (uint256);
+
+    /**
+     * @notice Maximum length in bytes of either peer string.
+     */
+    function MAX_PEER_STRING_LENGTH() external view returns (uint256);
+
+    /*//////////////////////////////////////////////////////////////
+                                STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Counter incremented by exactly one on every mutation.
+     * @dev Lets a poller detect change with one cheap call instead of fetching and diffing the whole
+     *      rendered document. Starts at zero, so a client whose watermark starts at zero correctly
+     *      treats deploy-time seeding as a change.
+     */
+    function configVersion() external view returns (uint256);
+
+    /**
+     * @notice Comma-separated multiaddrs a node dials on startup. May be empty.
+     */
+    function bootstrapPeers() external view returns (string memory);
+
+    /**
+     * @notice Comma-separated peer ids a node maintains direct connections to. May be empty.
+     */
+    function directPeers() external view returns (string memory);
+
+    /*//////////////////////////////////////////////////////////////
+                                GETTERS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Number of stored validator sets.
+     */
+    function validatorSetCount() external view returns (uint256);
+
+    /**
+     * @notice Get one validator set by index.
+     * @param index Index of the set to read.
+     * @return The validator set at that index.
+     */
+    function validatorSetAt(
+        uint256 index
+    ) external view returns (ValidatorSet memory);
+
+    /**
+     * @notice Get every stored validator set, in order.
+     */
+    function validatorSets() external view returns (ValidatorSet[] memory);
+
+    /*//////////////////////////////////////////////////////////////
+                         PERMISSIONED ACTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Append a validator set. Only callable by owner.
+     * @dev effectiveAt must be greater than or equal to that of the most recent preceding set
+     *      governing a shard in common; sets over disjoint shards are unconstrained relative to one
+     *      another, because each shard's height is an independent counter. Equality is permitted
+     *      because per-shard rollouts legitimately land at the same height.
+     * @param effectiveAt          Snapchain block height at which the set becomes active.
+     * @param shardIds             Shards this set governs.
+     * @param validatorPublicKeys  Ed25519 public keys in the set.
+     */
+    function appendValidatorSet(
+        uint64 effectiveAt,
+        uint32[] calldata shardIds,
+        bytes32[] calldata validatorPublicKeys
+    ) external;
+
+    /**
+     * @notice Overwrite the latest validator set in place. Only callable by owner.
+     * @dev History is append-only; only the tip may be amended. The same per-shard effectiveAt
+     *      bound against the preceding entries applies.
+     * @param effectiveAt          Snapchain block height at which the set becomes active.
+     * @param shardIds             Shards this set governs.
+     * @param validatorPublicKeys  Ed25519 public keys in the set.
+     */
+    function amendLatestValidatorSet(
+        uint64 effectiveAt,
+        uint32[] calldata shardIds,
+        bytes32[] calldata validatorPublicKeys
+    ) external;
+
+    /**
+     * @notice Drop the latest validator set. Only callable by owner.
+     * @dev Amending can only replace the tip with some other valid entry; there is no value meaning
+     *      "no entry". Since the owner can already rewrite the tip's contents, refusing to let them
+     *      delete it would be false rigor. The removal is still recorded as an event.
+     */
+    function removeLatestValidatorSet() external;
+
+    /**
+     * @notice Set the bootstrap peer list. Only callable by owner.
+     * @param peers Comma-separated multiaddrs, or the empty string.
+     */
+    function setBootstrapPeers(
+        string calldata peers
+    ) external;
+
+    /**
+     * @notice Set the direct peer list. Only callable by owner.
+     * @param peers Comma-separated peer ids, or the empty string.
+     */
+    function setDirectPeers(
+        string calldata peers
+    ) external;
+}


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] The PR's changes adhere to all the requirements in the [contribution guidelines](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#3-proposing-changes)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/contracts/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `ISnapchainConfigRegistry` interface and its implementation in the `SnapchainConfigRegistry` contract, establishing a governance structure for validator sets and peer lists in a Snapchain network.

### Detailed summary
- Added `ISnapchainConfigRegistry` interface with:
  - `ValidatorSet` struct.
  - Error definitions for validation.
  - Events for appending, amending, and removing validator sets.
  - Constants and storage functions.
- Implemented `SnapchainConfigRegistry` contract inheriting from `ISnapchainConfigRegistry`:
  - Defined constants for max shard IDs and public keys.
  - Storage for validator sets and peer lists.
  - Functions for managing validator sets and peer lists, including validation logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->